### PR TITLE
camelCase visitSequence + initial attempt passive imputation

### DIFF
--- a/R/common.R
+++ b/R/common.R
@@ -22,7 +22,8 @@
     length(imputationTargets) > 0 &&
     !is.null(nImp) && nImp >= 1 &&
     !is.null(nIter) && nIter >= 1 &&
-    !is.null(seed)
+    !is.null(seed) &&
+    ((passive && passiveImputation != "") | !passive)
   )
 }
 

--- a/R/common.R
+++ b/R/common.R
@@ -22,8 +22,7 @@
     length(imputationTargets) > 0 &&
     !is.null(nImp) && nImp >= 1 &&
     !is.null(nIter) && nIter >= 1 &&
-    !is.null(seed) &&
-    ((passive && passiveImputation != "") | !passive)
+    !is.null(seed)
   )
 }
 

--- a/inst/qml/MissingDataImputation.qml
+++ b/inst/qml/MissingDataImputation.qml
@@ -184,6 +184,20 @@ Form
 
 		}
 
+
+	}
+
+	DropDown
+	{
+		name: "visitsequence"
+
+		label: qsTr("Visit Sequence")
+		values: [
+			{ label: qsTr("Top to Bottom"), value: "roman"},
+			{ label: qsTr("Bottom to Top"),	value: "arabic"},
+			{ label: qsTr("Monotone"),	value: "monotone"},
+			{ label: qsTr("Reverse Monotone"),	value: "revmonotone"}
+		]
 	}
 
 	Group

--- a/inst/qml/MissingDataImputation.qml
+++ b/inst/qml/MissingDataImputation.qml
@@ -96,6 +96,22 @@ Form
 		}
 
 	}
+		CheckBox
+		{
+			name:		"passive"
+			label:		qsTr("Use passive imputation")
+			id:			passive
+			checked:	false
+		}
+	TextArea
+	{
+	  visible:	passive.checked
+		id: passiveImputation
+		name: "passiveImputation"
+		textType: JASP.PassiveImputation
+		showLineNumber: true
+	}
+
 
 	Group
 	{
@@ -189,7 +205,7 @@ Form
 
 	DropDown
 	{
-		name: "visitsequence"
+		name: "visitSequence"
 
 		label: qsTr("Visit Sequence")
 		values: [


### PR DESCRIPTION
Any ideas on transforming the unencoded variable names of the processed data (with type information etc.)?

```
$methVec
 JaspColumn_9_Encoded JaspColumn_18_Encoded JaspColumn_21_Encoded JaspColumn_12_Encoded 
                "pmm"                 "pmm"                 "pmm"                 "pmm" 
JaspColumn_15_Encoded 
                "pmm" 

$passiveMat
    bmi=wgt/(hgt/100)^2                                
var "JaspColumn_3_Encoded"                             
eq  "JaspColumn_2_Encoded/(JaspColumn_1_Encoded/100)^2"
```

I need the names from `$methVec`, but get the names as displayed in `$passiveMat`. Probably obsolete: this PR is not ready to be merged, yet.