### PR TITLE
Add imputation model specification options

### DIFF
--- a/R/missingDataImputation.R
+++ b/R/missingDataImputation.R
@@ -164,6 +164,9 @@ MissingDataImputation <- function(jaspResults, dataset, options) {
 
 .processPassive <- function(dataset, options, methodVector, predictorMatrix) {
 
+  #TODO: passive imputation might run before the other imputation models in the sequence.
+  # it might be wise to let it run after all other imputation models have been run. I now
+  # filed an issue on the mice github page.
   encodedMethNames <- names(methodVector)
   decodedMethNames <- jaspBase::decodeColNames(encodedMethNames)
 
@@ -243,7 +246,7 @@ predMatToModels <- function(predictorMatrix, variables) {
 
 
   impMods <- sapply(c(fullModelsVec, nullModelsVec, otherModsVec), as.formula)
-  impMods
+  impMods[match(encodedMethNames, sapply(impMods, as.character)[2,])]
 }
 
 ###------------------------------------------------------------------------------------------------------------------###

--- a/R/missingDataImputation.R
+++ b/R/missingDataImputation.R
@@ -279,7 +279,7 @@ predMatToModels <- function(predictorMatrix, variables) {
   methVec <- .makeMethodVector(dataset, options)
   predMat <- .makePredictorMatrix(dataset, options)
 
-  if (options$passive & options$passiveImputation != "") {
+  if (options$passiveImputation != "") {
     passive <- .processPassive(dataset, options, methVec, predMat)
     methVec <- passive$meth
     predMat <- passive$pred

--- a/R/missingDataImputation.R
+++ b/R/missingDataImputation.R
@@ -190,14 +190,6 @@ MissingDataImputation <- function(jaspResults, dataset, options) {
 
 ### Text-specified imputation models ---------------------------------------------------------------------------------###
 
-predMatToModels <- function(predictorMatrix, variables) {
-  sapply(variables, function(x) {
-    paste0(x, "~", paste0(names(which(predictorMatrix[x,]!=0)), collapse = "+"))
-  })
-}
-
-
-
 .processImpModel <- function(dataset, options, predictorMatrix) {
 
   encodedMethNames <- rownames(predictorMatrix)

--- a/R/missingDataImputation.R
+++ b/R/missingDataImputation.R
@@ -101,7 +101,17 @@ MissingDataImputation <- function(jaspResults, dataset, options) {
   if(!is.null(jaspResults[["MiceMids"]])) return()
 
   miceMids <- createJaspState()
-  miceMids$dependOn(options = c("imputationTargets", "imputationMethods", "passiveImputation", "visitSequence", "nImps", "nIter", "seed"))
+  miceMids$dependOn(options = c(
+    "imputationTargets",
+    "imputationMethods",
+    "passiveImputation",
+    "changeFullModel",
+    "changeNullModel",
+    "visitSequence",
+    "nImps",
+    "nIter",
+    "seed")
+  )
 
   jaspResults[["MiceMids"]] <- miceMids
 }

--- a/R/missingDataImputation.R
+++ b/R/missingDataImputation.R
@@ -233,9 +233,14 @@ predMatToModels <- function(predictorMatrix, variables) {
   }
 
   otherVars <- setdiff(c(encodedMethNames), c(fullModelsVars, nullModelsVars))
-  otherPreds <- lapply(otherVars, function(x) names(which(predictorMatrix[x,] != 0)))
-  otherPreds <- sapply(otherPreds, function(x) paste0(x, collapse = " + "))
-  otherModsVec <- paste0(otherVars, "~", otherPreds)
+  if (length(otherVars) > 0) {
+    otherPreds <- lapply(otherVars, function(x) names(which(predictorMatrix[x,] != 0)))
+    otherPreds <- sapply(otherPreds, function(x) paste0(x, collapse = " + "))
+    otherModsVec <- paste0(otherVars, "~", otherPreds)
+  } else {
+    otherModsVec <- NULL
+  }
+
 
   impMods <- sapply(c(fullModelsVec, nullModelsVec, otherModsVec), as.formula)
   impMods

--- a/R/missingDataImputation.R
+++ b/R/missingDataImputation.R
@@ -203,7 +203,8 @@ MissingDataImputation <- function(jaspResults, dataset, options) {
                             decoded = decodedMethNames)
 
     fullModelsVars <- fullModelsMat[1,]
-    fullModelsVec  <- paste0(fullModelsMat[1,], "~ . +", fullModels[2,])
+    firstchar <- substr(fullModelsMat[2,], 1, 1)
+    fullModelsVec  <- paste0(fullModelsVars, "~ .", ifelse(firstchar == "-", "", "+"), fullModelsMat[2,])
   } else {
     fullModelsVars <- NULL
     fullModelsVec  <- NULL
@@ -217,7 +218,7 @@ MissingDataImputation <- function(jaspResults, dataset, options) {
                             decoded = decodedMethNames)
 
     nullModelsVars <- nullModelsMat[1,]
-    nullModelsVec  <- paste0(nullModelsMat[1,], "~", nullModelsMat[2,])
+    nullModelsVec  <- paste0(nullModelsVars, "~", nullModelsMat[2,])
   } else {
     nullModelsVars <- NULL
     nullModelsVec  <- NULL

--- a/inst/qml/MissingDataImputation.qml
+++ b/inst/qml/MissingDataImputation.qml
@@ -277,7 +277,7 @@ Form
 	    name: "changePredOption"
 		  label: qsTr("Change imputation predictors")
 		  values: [
-		    { label: qsTr("Add/remove predictors"),		value: "addpred"},
+//		    { label: qsTr("Add/remove predictors"),		value: "addpred"},
 			  { label: qsTr("Fully flexible specification"),	value: "flex"}
 		  ]
 	  }

--- a/inst/qml/MissingDataImputation.qml
+++ b/inst/qml/MissingDataImputation.qml
@@ -96,6 +96,10 @@ Form
 		}
 
 	}
+	Group
+	{
+	  title: qsTr("Passive imputation")
+
 		CheckBox
 		{
 			name:		"passive"
@@ -103,15 +107,15 @@ Form
 			id:			passive
 			checked:	false
 		}
-	TextArea
-	{
-	  visible:	passive.checked
-		id: passiveImputation
-		name: "passiveImputation"
-		textType: JASP.PassiveImputation
-		showLineNumber: true
+	  TextArea
+	  {
+	    visible:	passive.checked
+		  id: passiveImputation
+		  name: "passiveImputation"
+		  textType: JASP.PassiveImputation
+		  showLineNumber: true
+	  }
 	}
-
 
 	Group
 	{
@@ -269,6 +273,33 @@ Form
 		}
 
 	}
+	Section
+	{
+	  id: predictorSpec
+	  title: qsTr("Imputation model specification")
+	  DropDown
+	  {
+	    id: changePredOption
+	    name: "changePredOption"
+		  label: qsTr("Change imputation predictors")
+		  values: [
+		    { label: qsTr("Add/remove predictors"),		value: "addpred"},
+			  { label: qsTr("Fully flexible specification"),	value: "flex"}
+		  ]
+	  }
+	  TextArea {
+	    id: changeNullModel
+	    name: "changeNullModel"
+	    placeholderText: qsTr("Add terms to an intercept-only model.")
+	    visible: changePredOption.currentValue === "flex"
+	  }
+	  TextArea {
+	    id: changeFullModel
+	    name: "changeFullModel"
+	    placeholderText: qsTr("Add terms to a full model (containing all main-effects).")
+	    visible: changePredOption.currentValue === "flex"
+	  }
+}
 
 	Section
 	{

--- a/inst/qml/MissingDataImputation.qml
+++ b/inst/qml/MissingDataImputation.qml
@@ -96,26 +96,6 @@ Form
 		}
 
 	}
-	Group
-	{
-	  title: qsTr("Passive imputation")
-
-		CheckBox
-		{
-			name:		"passive"
-			label:		qsTr("Use passive imputation")
-			id:			passive
-			checked:	false
-		}
-	  TextArea
-	  {
-	    visible:	passive.checked
-		  id: passiveImputation
-		  name: "passiveImputation"
-		  textType: JASP.PassiveImputation
-		  showLineNumber: true
-	  }
-	}
 
 	Group
 	{
@@ -272,6 +252,20 @@ Form
 			checked:	false
 		}
 
+	}
+	Section
+	{
+	  id: passiveImp
+	  title: qsTr("Passive imputation")
+
+	  TextArea
+	  {
+		  id: passiveImputation
+		  name: "passiveImputation"
+		  textType: JASP.PassiveImputation
+		  showLineNumber: true
+		  placeholderText: "Passive imputation models can be specified as:\na=b+(2*c)^2"
+	  }
 	}
 	Section
 	{


### PR DESCRIPTION
Took me three days to figure out `mice()` does not match the method vector and the order of variables in the formulas-list. But now it's set. Although it requires quite extensive testing still, I'm not so sure whether everything runs error free, always (also because this formula stuff is not so well documented). 

Also, sorry for including a mini-update on passive imputation (I thought hiding this behind a section bar is neater than the radiobutton). 

A review is much appreciated! I suspect there is potential for improvement in the `.processImpModel()` function.