### PR TITLE
More pooling & better QML

### DIFF
--- a/R/miLinearRegression.R
+++ b/R/miLinearRegression.R
@@ -15,31 +15,41 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-###------------------------------------------------------------------------------------------------------------------###
+### ------------------------------------------------------------------------------------------------------------------###
 
 .runRegression <- function(jaspResults, options, ready, lmFunction) {
-
   impData <- jaspResults[["MiceMids"]]$object |> mice::complete("all")
 
   # modelContainer <- .linregGetModelContainer(jaspResults, position = 1)
   modelContainer <- jaspResults[["ModelContainer"]]
-  model          <- .linregCalcModel(modelContainer, impData, options, ready, lmFunction)
+  model <- jaspRegression:::.linregCalcModel(modelContainer, impData, options, ready, lmFunction)
 
-  if (is.null(modelContainer[["summaryTable"]]))
-    .linregCreateSummaryTable(modelContainer, model, options, position = 1)
+  model[[1]][["rSquareChange"]] <- .pooledRSquaredChange(fit1 = model[[1]]$fit) # , fStat = options$fStat)
+
+  for (i in seq_along(model)[-1]) {
+    model[[i]][["rSquareChange"]] <-
+      .pooledRSquaredChange(fit1 = model[[i]]$fit, fit0 = model[[i - 1]]$fit) # , fStat = options$fStat)
+    # durbinWatson  <- model[[i]][["durbinWatson"]]
+  }
+
+  if (is.null(modelContainer[["summaryTable"]])) {
+    jaspRegression:::.linregCreateSummaryTable(modelContainer, model, options, position = 1)
+  }
 
   # TODO (KML): Check the R2, F, AIC/BIC stuff and put MI appropriate versions in
   # TODO (KML): Add footnotes about pooling
- 
-  if (options$modelFit && is.null(modelContainer[["anovaTable"]]))
-    .linregCreateAnovaTable(modelContainer, model, options, position = 2)
+
+  if (options$modelFit && is.null(modelContainer[["anovaTable"]])) {
+    jaspRegression:::.linregCreateAnovaTable(modelContainer, model, options, position = 2)
+  }
 
   # TODO (KML): Check the ANOVA stats.
   #             - Are they correct for MI data
   #             - Do they correctly adjust for D1, D2, D3?
 
-  if (options$coefficientEstimate && is.null(modelContainer[["coeffTable"]]))
-    .linregCreateCoefficientsTable(modelContainer, model, impData, options, position = 3)
+  if (options$coefficientEstimate && is.null(modelContainer[["coeffTable"]])) {
+    jaspRegression:::.linregCreateCoefficientsTable(modelContainer, model, impData, options, position = 3)
+  }
 
   # TODO (KML): Check what we can do about the bootstrapping, partial cor, and collinearity tables
 
@@ -49,14 +59,49 @@
   # if (options$partAndPartialCorrelation && is.null(modelContainer[["partialCorTable"]]))
   #   jaspRegression:::.linregCreatePartialCorrelationsTable(modelContainer, model, dataset, options, position = 6)
 
-  if (options$covarianceMatrix && is.null(modelContainer[["coeffCovMatrixTable"]]))
-    .linregCreateCoefficientsCovarianceMatrixTable(modelContainer, model, options, position = 4)
+  if (options$covarianceMatrix && is.null(modelContainer[["coeffCovMatrixTable"]])) {
+    jaspRegression:::.linregCreateCoefficientsCovarianceMatrixTable(modelContainer, model, options, position = 4)
+  }
 
   # if (options$collinearityDiagnostic && is.null(modelContainer[["collinearityTable"]]))
   #   jaspRegression:::.linregCreateCollinearityDiagnosticsTable(modelContainer, model, options, position = 8)
 }
 
 ## Execute .runRegression() within the 'jaspRegression' namespace:
-environment(.runRegression) <- asNamespace('jaspRegression')
+# environment(.runRegression) <- asNamespace("jaspRegression")
 
-###------------------------------------------------------------------------------------------------------------------###
+### ------------------------------------------------------------------------------------------------------------------###
+
+.pooledRSquaredChange <- function(fit1, fit0 = NULL) {
+  # fFun <- switch(fStat,
+  #   d1 = mice::D1,
+  #   d2 = mice::D2,
+  #   d3 = mice::D3
+  # )
+  #
+  if (is.null(fit0)) {
+    out <- list(
+      R2c = NA,
+      Fc  = NA,
+      df1 = 0,
+      df2 = fit1$df.residual,
+      p   = NA
+    )
+  } else {
+    fOut <- fit1$fFun(fit1 = fit1$fits, fit0 = fit0$fits)
+
+    out <- list(
+      R2c = fit1$pooled$r2[1, "est"] - fit0$pooled$r2[1, "est"],
+      Fc  = fOut$result[[1]],
+      df1 = fOut$result[[2]],
+      df2 = fOut$result[[3]],
+      p   = fOut$result[[4]]
+    )
+  }
+
+  out
+}
+
+# environment(.pooledRSquaredChange) <- asNamespace("jaspRegression")
+
+### ------------------------------------------------------------------------------------------------------------------###

--- a/R/miLinearRegression.R
+++ b/R/miLinearRegression.R
@@ -24,11 +24,11 @@
   modelContainer <- jaspResults[["ModelContainer"]]
   model <- jaspRegression:::.linregCalcModel(modelContainer, impData, options, ready, lmFunction)
 
-  model[[1]][["rSquareChange"]] <- .pooledRSquaredChange(fit1 = model[[1]]$fit) # , fStat = options$fStat)
+  ## We need to recompute the F-tests for the R2 changes since they're not pooled correctly in .linregCalcModel()
+  model[[1]][["rSquareChange"]] <- .pooledRSquaredChange(fit1 = model[[1]]$fit)
 
   for (i in seq_along(model)[-1]) {
-    model[[i]][["rSquareChange"]] <-
-      .pooledRSquaredChange(fit1 = model[[i]]$fit, fit0 = model[[i - 1]]$fit) # , fStat = options$fStat)
+    model[[i]][["rSquareChange"]] <- .pooledRSquaredChange(fit1 = model[[i]]$fit, fit0 = model[[i - 1]]$fit)
     # durbinWatson  <- model[[i]][["durbinWatson"]]
   }
 
@@ -73,12 +73,6 @@
 ### ------------------------------------------------------------------------------------------------------------------###
 
 .pooledRSquaredChange <- function(fit1, fit0 = NULL) {
-  # fFun <- switch(fStat,
-  #   d1 = mice::D1,
-  #   d2 = mice::D2,
-  #   d3 = mice::D3
-  # )
-  #
   if (is.null(fit0)) {
     out <- list(
       R2c = NA,
@@ -98,7 +92,6 @@
       p   = fOut$result[[4]]
     )
   }
-
   out
 }
 

--- a/R/missingDataImputation.R
+++ b/R/missingDataImputation.R
@@ -62,7 +62,8 @@ MissingDataImputation <- function(jaspResults, dataset, options) {
     "steppingMethodCriteriaFRemoval",
     "interceptTerm",
     "quadraticTerms",
-    "fType"
+    "fStat",
+    "llEst"
   )
 
   if (.readyForMi(options)) {
@@ -86,7 +87,7 @@ MissingDataImputation <- function(jaspResults, dataset, options) {
       .createDensityPlot(jaspResults[["ConvergencePlots"]], jaspResults[["MiceMids"]], options)
 
     if (options$runLinearRegression && .readyForLinReg(options, jaspResults[["MiceMids"]])) {
-      pooledLm <- makePooledLm(pool = TRUE, type = options$fType)
+      pooledLm <- makePooledLm(pool = TRUE, poolingParams = with(options, list(fStat = fStat, llEst = llEst)))
       .initModelContainer(jaspResults, c(imputationDependencies, regressionDependencies))
       .runRegression(jaspResults, options, ready = TRUE, lmFunction = pooledLm)
     }

--- a/R/pooledLm.R
+++ b/R/pooledLm.R
@@ -15,71 +15,76 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-###------------------------------------------------------------------------------------------------------------------###
+### ------------------------------------------------------------------------------------------------------------------###
 
 #' @export
 makePooledLm <- function(pool, poolingParams) {
   function(formula, data, weights, ...) {
-
     ## TIL that formula objects are closures that capture the environment in which they are created. So, we need to create
     ## the formula object in an environment containing 'weights', otherwise lm() won't find 'weights'.
     form <- as.formula(formula)
     environment(form) <- environment()
 
     fits <- vector("list", length(data))
-    for(m in 1:length(data))
+    for (m in 1:length(data)) {
       fits[[m]] <- lm(form, data = data[[m]], weights = weights[[m]], ...)
+    }
 
-    if(!pool) return(fits)
+    if (!pool) {
+      return(fits)
+    }
 
     pooledLmObject(fits, pooling = poolingParams)
   }
 }
 
-###------------------------------------------------------------------------------------------------------------------###
+### ------------------------------------------------------------------------------------------------------------------###
 
 #' @export
 pooledLmObject <- function(fits,
                            pooling = list(fStat = "d3", llEst = "qBar"),
-                           include = list(model = FALSE, qr = FALSE, x = FALSE)
-                           )
-{
+                           include = list(fits = TRUE, model = FALSE, qr = FALSE, x = FALSE)) {
   fits <- .checkInputs(fits, pooling)
 
   ## Much of the lm object doesn't change across imputed datasets, so we can keep one of the original fits and replace
   ## the appropriate parts with MI-based estimates.
-  obj        <- fits$analyses[[1]]
+  obj <- fits$analyses[[1]]
   class(obj) <- c("pooledlm", class(obj))
 
   ## We need to extract these things before casting the 'fits' as a mira object:
   residuals <- sapply(fits$analyses, resid)
-  yHats     <- sapply(fits$analyses, fitted)
-  effects   <- sapply(fits$analyses, effects)
+  yHats <- sapply(fits$analyses, fitted)
+  effects <- sapply(fits$analyses, effects)
 
   ## The pooled estimates of linear effects are just the arithmetic mean across imputations:
-  obj$residuals     <- rowMeans(residuals)
+  obj$residuals <- rowMeans(residuals)
   obj$fitted.values <- rowMeans(yHats)
-  obj$effects       <- rowMeans(effects)
+  obj$effects <- rowMeans(effects)
 
   obj$singularityCheckValue <- sapply(fits$analyses, function(x) x$qr$qr |> ncol()) |> min()
 
   ## Do we keep the stuff we can't pool?
-  if(include$model) obj$model <- lapply(fits$analyses, "[[", x = "model") else obj$model <- NA
-  if(include$qr)    obj$qr    <- lapply(fits$analyses, "[[", x = "qr")    else obj$qr    <- NA
-  if(include$x)     obj$x     <- lapply(fits$analyses, "[[", x = "x")     else obj$x     <- NA
+  if (include$fits) obj$fits <- fits
+  if (include$model) obj$model <- lapply(fits$analyses, "[[", x = "model") else obj$model <- NA
+  if (include$qr) obj$qr <- lapply(fits$analyses, "[[", x = "qr") else obj$qr <- NA
+  if (include$x) obj$x <- lapply(fits$analyses, "[[", x = "x") else obj$x <- NA
 
   ## Use the mice pooling routines for the more complicated cases:
-  pooled      <- list()
+  pooled <- list()
   pooled$coef <- mice::pool(fits)
-  pooled$r2   <- mice::pool.r.squared(fits)
-  pooled$r2A  <- mice::pool.r.squared(fits, adjusted = TRUE)
+  pooled$r2 <- mice::pool.r.squared(fits)
+  pooled$r2A <- mice::pool.r.squared(fits, adjusted = TRUE)
 
   if (obj$rank > 1) { # We can only compute pooled F when we have some predictors
-    fFun            <- switch(pooling$fStat, d1 = mice::D1, d2 = mice::D2, d3 = mice::D3)
-    pooled$f        <- fFun(fits)
+    obj$fFun <- switch(pooling$fStat,
+      d1 = mice::D1,
+      d2 = mice::D2,
+      d3 = mice::D3
+    )
+    pooled$f <- obj$fFun(fits)
     obj$df.residual <- as.numeric(pooled$f$result)[3]
   } else if (obj$rank == 1) { # We're pooling an intercept-only model
-    pooled$f        <- NULL
+    pooled$f <- NULL
     obj$df.residual <- pooled$coef$pooled$df
   } else {
     stop("Wow! Something has gone terribly wrong. You should not be able to access this condition.")
@@ -88,20 +93,21 @@ pooledLmObject <- function(fits,
   pooled$logLik <- .pooledLogLik(fits, est = pooling$llEst, pool = TRUE)
 
   ## Replace pool-able stats with their pooled versions
-  obj$coefficients        <- pooled$coef$pooled$estimate
+  obj$coefficients <- pooled$coef$pooled$estimate
   names(obj$coefficients) <- as.character(pooled$coef$pooled$term)
 
   ## Calculate the pooled residual variance:
-  resVars   <- pooled$coef$glanced$sigma^2
-  w         <- mean(resVars)
-  b         <- var(resVars)
+  resVars <- pooled$coef$glanced$sigma^2
+  w <- mean(resVars)
+  b <- var(resVars)
   pooled$s2 <- w + b + (b / length(fits))
 
   ## Calculate the pooled asymptotic covariance matrix of the regression coefficients:
-  if(obj$rank > 1)
+  if (obj$rank > 1) {
     pooled$vcov <- .pooledAsymptoticCov(fits$analyses)
-  else
+  } else {
     pooled$vcov <- with(pooled$coef$pooled, matrix(ubar + b + (b / m), dimnames = list(term, term)))
+  }
 
   ## Include the extra pooled stats we'll need downstream
   obj$pooled <- pooled
@@ -109,11 +115,12 @@ pooledLmObject <- function(fits,
   obj
 }
 
-###------------------------------------------------------------------------------------------------------------------###
+### ------------------------------------------------------------------------------------------------------------------###
 
 .checkInputs <- function(fits, pooling) {
-  if (!(mice::is.mira(fits) || is.list(fits)))
+  if (!(mice::is.mira(fits) || is.list(fits))) {
     stop("The 'fits' argument must be a a 'mira' object or list of fitted lm models.")
+  }
 
   if (!mice::is.mira(fits)) {
     fitsAreLm <- sapply(fits, inherits, what = "lm")
@@ -123,10 +130,12 @@ pooledLmObject <- function(fits,
     fits <- mice::as.mira(fits)
   }
 
-  if (!pooling$fStat %in% paste0("d", 1:3))
+  if (!pooling$fStat %in% paste0("d", 1:3)) {
     stop("The pooling type for F-statistics must be 'd1', 'd2', or 'd3'.")
-  if (!pooling$llEst %in% c("qBar", "qHat"))
+  }
+  if (!pooling$llEst %in% c("qBar", "qHat")) {
     stop("The estimate type at which to evaluate the log-likelihood must be 'qBar' or 'qHat'.")
+  }
 
   ranks <- sapply(fits$analyses, "[[", x = "rank")
   if (any(ranks <= 0)) stop("I don't know how to pool models with rank(X) < 1.")
@@ -134,28 +143,30 @@ pooledLmObject <- function(fits,
   fits
 }
 
-###------------------------------------------------------------------------------------------------------------------###
+### ------------------------------------------------------------------------------------------------------------------###
 
 #' @export
 summary.pooledlm <- function(object, ...) {
   out <- structure(list(), class = c("summary.pooledlm", "summary.lm")) # Maybe we can just use the print method for summary.lm ?
 
   ## We can pull a few things directly from the input object
-  out$call      <- object$call
+  out$call <- object$call
   out$residuals <- object$residuals
-  out$terms     <- object$terms
-  out$weights   <- object$weights
+  out$terms <- object$terms
+  out$weights <- object$weights
 
   ## Tidy up the fit related stuff
-  out$r.squared     <- object$pooled$r2[1, "est"]
+  out$r.squared <- object$pooled$r2[1, "est"]
   out$adj.r.squared <- object$pooled$r2A[1, "est"]
-  out$sigma         <- object$pooled$s2 |> sqrt()
+  out$sigma <- object$pooled$s2 |> sqrt()
 
   ## Reverse engineer the unscaled covariance matrix:
   out$cov.unscaled <- with(object$pooled, vcov / s2)
 
   if (object$rank > 1) {
-    f <- object$pooled$f$result |> as.numeric() |> head(3)
+    f <- object$pooled$f$result |>
+      as.numeric() |>
+      head(3)
     names(f) <- c("value", "numdf", "dendf")
     out$fstatistic <- f
   }
@@ -164,33 +175,35 @@ summary.pooledlm <- function(object, ...) {
   pooledCoefSum <- summary(object$pooled$coef)
 
   ## The coefficients table needs formatting
-  coefTab <- with(pooledCoefSum,
+  coefTab <- with(
+    pooledCoefSum,
     cbind("Estimate" = estimate, "Std. Error" = std.error, "t value" = statistic, "Pr(>|t|)" = p.value)
   )
   rownames(coefTab) <- pooledCoefSum$term
-  out$coefficients  <- coefTab
+  out$coefficients <- coefTab
 
   ## Some values used for printing
   out$aliased <- is.na(object$coefficients)
-  out$df      <- with(object, c(rank, df.residual, singularityCheckValue))
+  out$df <- with(object, c(rank, df.residual, singularityCheckValue))
 
   invisible(out)
 }
 
-###------------------------------------------------------------------------------------------------------------------###
+### ------------------------------------------------------------------------------------------------------------------###
 
 #' @export
-print.summary.pooledlm <- function(object, allowStarGazing = FALSE, ...)
+print.summary.pooledlm <- function(object, allowStarGazing = FALSE, ...) {
   stats:::print.summary.lm(object, signif.stars = allowStarGazing, ...)
+}
 
-###------------------------------------------------------------------------------------------------------------------###
+### ------------------------------------------------------------------------------------------------------------------###
 
 #' @export
-coef.pooledlm   <- function(object) object$coefficients
+coef.pooledlm <- function(object) object$coefficients
 #' @export
-vcov.pooledlm   <- function(object) object$pooled$vcov
+vcov.pooledlm <- function(object) object$pooled$vcov
 #' @export
-resid.pooledlm  <- function(object) object$residuals
+resid.pooledlm <- function(object) object$residuals
 #' @export
 fitted.pooledlm <- function(object) object$fitted.values
 #' @export
@@ -200,16 +213,18 @@ logLik.pooledlm <- function(object) object$pooled$logLik
 #' @export
 # BIC.pooledlm    <- function(object, ...) object$pooled$infoCriteria$bic
 
-###------------------------------------------------------------------------------------------------------------------###
+### ------------------------------------------------------------------------------------------------------------------###
 
 .pooledAsymptoticCov <- function(fits) {
   m <- length(fits)
 
-  coefs     <- sapply(fits, coef)
+  coefs <- sapply(fits, coef)
   coefNames <- rownames(coefs)
 
   ## Between-imputation var/covar:
-  b <- coefs |> t() |> var()
+  b <- coefs |>
+    t() |>
+    var()
 
   ## Average within-imputation var/covar:
   w <- sapply(fits, vcov) |>
@@ -220,7 +235,7 @@ logLik.pooledlm <- function(object) object$pooled$logLik
   w + b + (b / m)
 }
 
-###------------------------------------------------------------------------------------------------------------------###
+### ------------------------------------------------------------------------------------------------------------------###
 
 .pooledLogLik <- function(fits, est = "qBar", pool = TRUE) {
   if (est == "qBar") {
@@ -234,13 +249,13 @@ logLik.pooledlm <- function(object) object$pooled$logLik
   if (pool) ll <- mean(ll)
 
   attr(ll, "nobs") <- fits$analyses[[1]]$residuals |> length()
-  attr(ll, "df")   <- fits$analyses[[1]]$rank + 1
-  class(ll)        <- "logLik"
+  attr(ll, "df") <- fits$analyses[[1]]$rank + 1
+  class(ll) <- "logLik"
 
   ll
 }
 
-###------------------------------------------------------------------------------------------------------------------###
+### ------------------------------------------------------------------------------------------------------------------###
 
 ## Pool AIC and BIC via naive averaging or the "Pooled Paramters - Pooled Log-Likelihoods" method proposed in
 ## https://doi.org/10.1007/s41237-025-00281-6
@@ -264,4 +279,4 @@ logLik.pooledlm <- function(object) object$pooled$logLik
 #   list(aic = aic, bic = bic, p = p, n = n, type = type)
 # }
 
-###------------------------------------------------------------------------------------------------------------------###
+### ------------------------------------------------------------------------------------------------------------------###

--- a/R/pooledLm.R
+++ b/R/pooledLm.R
@@ -18,7 +18,7 @@
 ###------------------------------------------------------------------------------------------------------------------###
 
 #' @export
-makePooledLm <- function(pool, type) {
+makePooledLm <- function(pool, poolingParams) {
   function(formula, data, weights, ...) {
 
     ## TIL that formula objects are closures that capture the environment in which they are created. So, we need to create
@@ -32,7 +32,7 @@ makePooledLm <- function(pool, type) {
 
     if(!pool) return(fits)
 
-    pooledLmObject(fits, fType = type)
+    pooledLmObject(fits, pooling = poolingParams)
   }
 }
 
@@ -40,11 +40,11 @@ makePooledLm <- function(pool, type) {
 
 #' @export
 pooledLmObject <- function(fits,
-                           fType = 1,
+                           pooling = list(fStat = "d3", llEst = "qBar"),
                            include = list(model = FALSE, qr = FALSE, x = FALSE)
                            )
 {
-  fits <- .checkInputs(fits, fType)
+  fits <- .checkInputs(fits, pooling)
 
   ## Much of the lm object doesn't change across imputed datasets, so we can keep one of the original fits and replace
   ## the appropriate parts with MI-based estimates.
@@ -75,7 +75,7 @@ pooledLmObject <- function(fits,
   pooled$r2A  <- mice::pool.r.squared(fits, adjusted = TRUE)
 
   if (obj$rank > 1) { # We can only compute pooled F when we have some predictors
-    fFun            <- switch(fType, d1 = mice::D1, d2 = mice::D2, d3 = mice::D3)
+    fFun            <- switch(pooling$fStat, d1 = mice::D1, d2 = mice::D2, d3 = mice::D3)
     pooled$f        <- fFun(fits)
     obj$df.residual <- as.numeric(pooled$f$result)[3]
   } else if (obj$rank == 1) { # We're pooling an intercept-only model
@@ -84,6 +84,8 @@ pooledLmObject <- function(fits,
   } else {
     stop("Wow! Something has gone terribly wrong. You should not be able to access this condition.")
   }
+
+  pooled$logLik <- .pooledLogLik(fits, est = pooling$llEst, pool = TRUE)
 
   ## Replace pool-able stats with their pooled versions
   obj$coefficients        <- pooled$coef$pooled$estimate
@@ -109,7 +111,7 @@ pooledLmObject <- function(fits,
 
 ###------------------------------------------------------------------------------------------------------------------###
 
-.checkInputs <- function(fits, fType) {
+.checkInputs <- function(fits, pooling) {
   if (!(mice::is.mira(fits) || is.list(fits)))
     stop("The 'fits' argument must be a a 'mira' object or list of fitted lm models.")
 
@@ -121,7 +123,10 @@ pooledLmObject <- function(fits,
     fits <- mice::as.mira(fits)
   }
 
-  if (!fType %in% paste0("d", 1:3)) stop("The 'fType' argument must be 'd1', 'd2', or 'd3'.")
+  if (!pooling$fStat %in% paste0("d", 1:3))
+    stop("The pooling type for F-statistics must be 'd1', 'd2', or 'd3'.")
+  if (!pooling$llEst %in% c("qBar", "qHat"))
+    stop("The estimate type at which to evaluate the log-likelihood must be 'qBar' or 'qHat'.")
 
   ranks <- sapply(fits$analyses, "[[", x = "rank")
   if (any(ranks <= 0)) stop("I don't know how to pool models with rank(X) < 1.")
@@ -181,13 +186,19 @@ print.summary.pooledlm <- function(object, allowStarGazing = FALSE, ...)
 ###------------------------------------------------------------------------------------------------------------------###
 
 #' @export
-coef.pooledlm   <- function(object, ...) object$coefficients
+coef.pooledlm   <- function(object) object$coefficients
 #' @export
-vcov.pooledlm   <- function(object, ...) object$pooled$vcov
+vcov.pooledlm   <- function(object) object$pooled$vcov
 #' @export
-resid.pooledlm  <- function(object, ...) object$residuals
+resid.pooledlm  <- function(object) object$residuals
 #' @export
-fitted.pooledlm <- function(object, ...) object$fitted.values
+fitted.pooledlm <- function(object) object$fitted.values
+#' @export
+logLik.pooledlm <- function(object) object$pooled$logLik
+#' @export
+# AIC.pooledlm    <- function(object, ...) object$pooled$infoCriteria$aic
+#' @export
+# BIC.pooledlm    <- function(object, ...) object$pooled$infoCriteria$bic
 
 ###------------------------------------------------------------------------------------------------------------------###
 
@@ -208,5 +219,49 @@ fitted.pooledlm <- function(object, ...) object$fitted.values
   ## Total var/covar:
   w + b + (b / m)
 }
+
+###------------------------------------------------------------------------------------------------------------------###
+
+.pooledLogLik <- function(fits, est = "qBar", pool = TRUE) {
+  if (est == "qBar") {
+    ll <- mice::D3(fits)$deviances$dev1.L / -2
+  } else if (est == "qHat") {
+    ll <- sapply(fits$analyses, logLik)
+  } else {
+    stop(paste0("The 'est' argument is currently '", est, "' but it should be either 'qBar' or 'qHat'."))
+  }
+
+  if (pool) ll <- mean(ll)
+
+  attr(ll, "nobs") <- fits$analyses[[1]]$residuals |> length()
+  attr(ll, "df")   <- fits$analyses[[1]]$rank + 1
+  class(ll)        <- "logLik"
+
+  ll
+}
+
+###------------------------------------------------------------------------------------------------------------------###
+
+## Pool AIC and BIC via naive averaging or the "Pooled Paramters - Pooled Log-Likelihoods" method proposed in
+## https://doi.org/10.1007/s41237-025-00281-6
+# .pooledInfoCriteria <- function(fits, type = "ppl") {
+#   d3 <- mice::D3(fits)
+
+#   ll <- d3$deviances$dev1.L
+#   p <- coef(fits$analyses[[1]]) |> length() + 1
+#   n <- fits$analyses[[1]]$model |> nrow()
+
+#   if (type == "ppl") {
+#     aic <- (ll + 2 * p) |> mean()
+#     bic <- (ll + log(n) * p) |> mean()
+#   } else if (type == "avg") {
+#     aic <- sapply(fits$analyses, AIC) |> mean()
+#     bic <- sapply(fits$analyses, BIC) |> mean()
+#   } else {
+#     stop(paste0("'", type, "' is not a valid type of pooling for information criteria."))
+#   }
+
+#   list(aic = aic, bic = bic, p = p, n = n, type = type)
+# }
 
 ###------------------------------------------------------------------------------------------------------------------###

--- a/inst/qml/MissingDataImputation.qml
+++ b/inst/qml/MissingDataImputation.qml
@@ -26,7 +26,7 @@ import "./imputation"	as	Imputation
 Form
 {
 
-	Imputation.HeadlessImputation {}
+	Imputation.HeadlessImputation { id: imputation }
 
 	Group
 	{
@@ -51,6 +51,6 @@ Form
 
 	}
 
-	Regression.RegressionLinear {}
+	Regression.RegressionLinear { imputedVariables: imputation.impVars }
 
 }

--- a/inst/qml/imputation/HeadlessImputation.qml
+++ b/inst/qml/imputation/HeadlessImputation.qml
@@ -24,7 +24,9 @@ import JASP.Controls
 // This headless file is meant to be included as a QML component elsewhere
 Group
 {
-	Variables {}
+	property alias impVars:	variables.impVars
+
+	Variables { id:	variables }
 	Parameterization {}
 	PredictorMatrix {}
 	ModelSpec {}

--- a/inst/qml/imputation/Variables.qml
+++ b/inst/qml/imputation/Variables.qml
@@ -23,6 +23,8 @@ import JASP.Controls
 VariablesForm
 {
 
+	property alias impVars:	impVars
+
 	AvailableVariablesList
 	{
 		name:	"allVariables"

--- a/inst/qml/regression/RegressionLinear.qml
+++ b/inst/qml/regression/RegressionLinear.qml
@@ -26,7 +26,9 @@ Section
 	id:		regressionAnalysis
 	title:	qsTr("Regression Analysis")
 
-	Variables {}
+	property var imputedVariables
+
+	Variables { candidateVariables: imputedVariables }
 	Model {}
 	Statistics {}
 	Methods {}

--- a/inst/qml/regression/Statistics.qml
+++ b/inst/qml/regression/Statistics.qml
@@ -87,18 +87,32 @@ Section
 
 	Group
 	{
+
 		title:	qsTr("Pooling")
+
 		DropDown
 		{
-			name: "fType"
-			label: qsTr("Pooling Rule for F-Statistic")
+			name: "fStat"
+			label: qsTr("Type of F-Statistic")
 			values: [
-				{ label: qsTr("D1"),	value: "d1"},
-				{ label: qsTr("D2"),	value: "d2"},
-				{ label: qsTr("D3"),	value: "d3"}
+				{ label: qsTr("D1"),	value: "d1" },
+				{ label: qsTr("D2"),	value: "d2" },
+				{ label: qsTr("D3"),	value: "d3" }
 			]
-			startValue: "1"
+			startValue: "d3"
 		}
+
+		DropDown
+		{
+			name: "llEst"
+			label: qsTr("Type of Log-Likelihood")
+			values: [
+				{ label: qsTr("Evaluated at Q-Hat"),	value: "qHat" },
+				{ label: qsTr("Evaluated at Q-Bar"),	value: "qBar" }
+			]
+			startValue: "qBar"
+		}
+
 	}
 
 	// Common.OutlierComponent { id: outlierComponentt}

--- a/inst/qml/regression/Variables.qml
+++ b/inst/qml/regression/Variables.qml
@@ -22,8 +22,10 @@ import JASP.Controls
 
 VariablesForm
 {
-	AvailableVariablesList { name: "allVariablesList" }
-	AssignedVariablesList { name: "dependent";	title: qsTr("Dependent Variable"); info: qsTr("Dependent variable.")	; allowedColumns: ["scale"]; singleVariable: true;		}
+	property var candidateVariables
+
+	AvailableVariablesList { name: "allVariablesList";	source: candidateVariables }
+	AssignedVariablesList { name: "dependent";	title: qsTr("Dependent Variable"); info: qsTr("Dependent variable."); allowedColumns: ["scale"]; singleVariable: true }
 	DropDown
 	{
 		name: "method"

--- a/renv.lock
+++ b/renv.lock
@@ -935,7 +935,7 @@
     },
     "bayestestR": {
       "Package": "bayestestR",
-      "Version": "0.17.0",
+      "Version": "0.18.0",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Understand and Describe Bayesian Models and Posterior Distributions",
@@ -946,8 +946,8 @@
         "R (>= 3.6)"
       ],
       "Imports": [
-        "insight (>= 1.4.1)",
-        "datawizard (>= 1.2.0)",
+        "insight (>= 1.5.0.6)",
+        "datawizard (>= 1.3.1)",
         "graphics",
         "methods",
         "stats",
@@ -960,7 +960,7 @@
         "betareg",
         "BH",
         "blavaan",
-        "bridgesampling",
+        "bridgesampling (>= 1.2-1)",
         "brms",
         "collapse",
         "curl",
@@ -1003,7 +1003,7 @@
       "VignetteBuilder": "knitr",
       "Encoding": "UTF-8",
       "Language": "en-US",
-      "RoxygenNote": "7.3.2",
+      "RoxygenNote": "7.3.3",
       "Config/testthat/edition": "3",
       "Config/testthat/parallel": "true",
       "Config/rcmdcheck/ignore-inconsequential-notes": "true",
@@ -1070,7 +1070,7 @@
     },
     "bit64": {
       "Package": "bit64",
-      "Version": "4.8.0",
+      "Version": "4.8.2",
       "Source": "Repository",
       "Title": "A S3 Class for Vectors of 64bit Integers",
       "Authors@R": "c( person(\"Michael\", \"Chirico\", email=\"michaelchirico4@gmail.com\", role=c(\"aut\", \"cre\")), person(\"Jens\", \"Oehlschlägel\", role=\"aut\"), person(\"Leonardo\", \"Silvestri\", role=\"ctb\"), person(\"Ofek\", \"Shilon\", role=\"ctb\"), person(\"Christian\", \"Ullerich\", role=\"ctb\") )",
@@ -1180,7 +1180,7 @@
     },
     "broom": {
       "Package": "broom",
-      "Version": "1.0.12",
+      "Version": "1.0.13",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Convert Statistical Objects into Tidy Tibbles",
@@ -1303,7 +1303,7 @@
     },
     "bslib": {
       "Package": "bslib",
-      "Version": "0.10.0",
+      "Version": "0.11.0",
       "Source": "Repository",
       "Title": "Custom 'Bootstrap' 'Sass' Themes for 'shiny' and 'rmarkdown'",
       "Authors@R": "c( person(\"Carson\", \"Sievert\", , \"carson@posit.co\", role = c(\"aut\", \"cre\"), comment = c(ORCID = \"0000-0002-4958-2844\")), person(\"Joe\", \"Cheng\", , \"joe@posit.co\", role = \"aut\"), person(\"Garrick\", \"Aden-Buie\", , \"garrick@posit.co\", role = \"aut\", comment = c(ORCID = \"0000-0002-7111-0077\")), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")), person(, \"Bootstrap contributors\", role = \"ctb\", comment = \"Bootstrap library\"), person(, \"Twitter, Inc\", role = \"cph\", comment = \"Bootstrap library\"), person(\"Javi\", \"Aguilar\", role = c(\"ctb\", \"cph\"), comment = \"Bootstrap colorpicker library\"), person(\"Thomas\", \"Park\", role = c(\"ctb\", \"cph\"), comment = \"Bootswatch library\"), person(, \"PayPal\", role = c(\"ctb\", \"cph\"), comment = \"Bootstrap accessibility plugin\") )",
@@ -1340,7 +1340,7 @@
         "magrittr",
         "rappdirs",
         "rmarkdown (>= 2.7)",
-        "shiny (>= 1.11.1)",
+        "shiny (>= 1.11.1.9000)",
         "testthat",
         "thematic",
         "tools",
@@ -1351,12 +1351,12 @@
       "Config/Needs/deploy": "BH, chiflights22, colourpicker, commonmark, cpp11, cpsievert/chiflights22, cpsievert/histoslider, dplyr, DT, ggplot2, ggridges, gt, hexbin, histoslider, htmlwidgets, lattice, leaflet, lubridate, markdown, modelr, plotly, reactable, reshape2, rprojroot, rsconnect, rstudio/shiny, scales, styler, tibble",
       "Config/Needs/routine": "chromote, desc, renv",
       "Config/Needs/website": "brio, crosstalk, dplyr, DT, ggplot2, glue, htmlwidgets, leaflet, lorem, palmerpenguins, plotly, purrr, rprojroot, rstudio/htmltools, scales, stringr, tidyr, webshot2",
+      "Config/roxygen2/version": "8.0.0",
       "Config/testthat/edition": "3",
       "Config/testthat/parallel": "true",
       "Config/testthat/start-first": "zzzz-bs-sass, fonts, zzz-precompile, theme-*, rmd-*",
       "Encoding": "UTF-8",
-      "RoxygenNote": "7.3.3",
-      "Collate": "'accordion.R' 'breakpoints.R' 'bs-current-theme.R' 'bs-dependencies.R' 'bs-global.R' 'bs-remove.R' 'bs-theme-layers.R' 'bs-theme-preset-bootswatch.R' 'bs-theme-preset-brand.R' 'bs-theme-preset-builtin.R' 'bs-theme-preset.R' 'utils.R' 'bs-theme-preview.R' 'bs-theme-update.R' 'bs-theme.R' 'bslib-package.R' 'buttons.R' 'card.R' 'deprecated.R' 'files.R' 'fill.R' 'imports.R' 'input-code-editor.R' 'input-dark-mode.R' 'input-submit.R' 'input-switch.R' 'layout.R' 'nav-items.R' 'nav-update.R' 'navbar_options.R' 'navs-legacy.R' 'navs.R' 'onLoad.R' 'page.R' 'popover.R' 'precompiled.R' 'print.R' 'shiny-devmode.R' 'sidebar.R' 'staticimports.R' 'toast.R' 'tooltip.R' 'utils-deps.R' 'utils-shiny.R' 'utils-tags.R' 'value-box.R' 'version-default.R' 'versions.R'",
+      "Collate": "'accordion.R' 'breakpoints.R' 'bs-current-theme.R' 'bs-dependencies.R' 'bs-global.R' 'bs-remove.R' 'bs-theme-layers.R' 'bs-theme-preset-bootswatch.R' 'bs-theme-preset-brand.R' 'bs-theme-preset-builtin.R' 'bs-theme-preset.R' 'utils.R' 'bs-theme-preview.R' 'bs-theme-update.R' 'bs-theme.R' 'bslib-package.R' 'buttons.R' 'card.R' 'deprecated.R' 'files.R' 'fill.R' 'imports.R' 'input-code-editor.R' 'input-dark-mode.R' 'input-submit.R' 'input-switch.R' 'layout.R' 'nav-items.R' 'nav-update.R' 'navbar_options.R' 'navs-legacy.R' 'navs.R' 'onLoad.R' 'page.R' 'popover.R' 'precompiled.R' 'print.R' 'shiny-devmode.R' 'sidebar.R' 'staticimports.R' 'toast.R' 'toolbar.R' 'tooltip.R' 'utils-deps.R' 'utils-shiny.R' 'utils-tags.R' 'value-box.R' 'version-default.R' 'versions.R'",
       "NeedsCompilation": "no",
       "Author": "Carson Sievert [aut, cre] (ORCID: <https://orcid.org/0000-0002-4958-2844>), Joe Cheng [aut], Garrick Aden-Buie [aut] (ORCID: <https://orcid.org/0000-0002-7111-0077>), Posit Software, PBC [cph, fnd], Bootstrap contributors [ctb] (Bootstrap library), Twitter, Inc [cph] (Bootstrap library), Javi Aguilar [ctb, cph] (Bootstrap colorpicker library), Thomas Park [ctb, cph] (Bootswatch library), PayPal [ctb, cph] (Bootstrap accessibility plugin)",
       "Maintainer": "Carson Sievert <carson@posit.co>",
@@ -4841,7 +4841,7 @@
     },
     "insight": {
       "Package": "insight",
-      "Version": "1.5.0",
+      "Version": "1.5.1",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Easy Access to Model Information for Various Model Objects",
@@ -4867,6 +4867,7 @@
         "BayesFactor",
         "bayestestR",
         "bbmle",
+        "BSDA",
         "bdsmatrix",
         "betareg",
         "biglm",
@@ -5000,11 +5001,11 @@
       "VignetteBuilder": "knitr",
       "Encoding": "UTF-8",
       "Language": "en-US",
-      "RoxygenNote": "7.3.3",
       "Config/testthat/edition": "3",
       "Config/testthat/parallel": "true",
       "Config/Needs/website": "easystats/easystatstemplate",
       "Config/Needs/check": "stan-dev/cmdstanr",
+      "Config/roxygen2/version": "8.0.0",
       "NeedsCompilation": "no",
       "Author": "Daniel Lüdecke [aut, cre] (ORCID: <https://orcid.org/0000-0002-8895-3206>), Dominique Makowski [aut, ctb] (ORCID: <https://orcid.org/0000-0001-5375-9967>), Indrajeet Patil [aut, ctb] (ORCID: <https://orcid.org/0000-0003-1995-6531>), Philip Waggoner [aut, ctb] (ORCID: <https://orcid.org/0000-0002-7825-7573>), Mattan S. Ben-Shachar [aut, ctb] (ORCID: <https://orcid.org/0000-0002-4287-4801>), Brenton M. Wiernik [aut, ctb] (ORCID: <https://orcid.org/0000-0001-9560-6336>), Vincent Arel-Bundock [aut, ctb] (ORCID: <https://orcid.org/0000-0003-2042-7063>), Etienne Bacher [aut, ctb] (ORCID: <https://orcid.org/0000-0002-9271-5075>), Alex Hayes [rev] (ORCID: <https://orcid.org/0000-0002-4985-5160>), Grant McDermott [ctb] (ORCID: <https://orcid.org/0000-0001-7883-8573>), Rémi Thériault [ctb] (ORCID: <https://orcid.org/0000-0003-4315-6788>), Alex Reinhart [ctb] (ORCID: <https://orcid.org/0000-0002-6658-514X>)",
       "Repository": "CRAN"
@@ -5114,11 +5115,11 @@
       "RoxygenNote": "7.3.2",
       "RemoteType": "github",
       "Remotes": "jasp-stats/jaspBase, jasp-stats/jaspDescriptives, jasp-stats/jaspGraphs, jasp-stats/jaspTTests",
+      "RemoteHost": "api.github.com",
       "RemoteUsername": "jasp-stats",
       "RemoteRepo": "jaspAnova",
       "RemoteRef": "master",
-      "RemoteSha": "a0d8fdb74ecc5e760d16e5ff04f8be9d8c0a3a85",
-      "RemoteHost": "api.github.com"
+      "RemoteSha": "61a62c27a08aac0881afa7af4e039a76eeb4632a"
     },
     "jaspBase": {
       "Package": "jaspBase",
@@ -5172,7 +5173,7 @@
       "RemoteUsername": "jasp-stats",
       "RemoteRepo": "jaspBase",
       "RemoteRef": "master",
-      "RemoteSha": "0f9bd7d846d8432301ccf7bbdcdadcb350df0704"
+      "RemoteSha": "244c661b7a4cdcc9aca0aacbf5555881d90c0985"
     },
     "jaspDescriptives": {
       "Package": "jaspDescriptives",
@@ -5212,7 +5213,7 @@
       "RemoteUsername": "jasp-stats",
       "RemoteRepo": "jaspDescriptives",
       "RemoteRef": "master",
-      "RemoteSha": "fd5479ee5ec7567f7a7c86c40791f54b3370f8af"
+      "RemoteSha": "e522dbcdbc6e2e39ed0e7c9ceb83e0114af38045"
     },
     "jaspGraphs": {
       "Package": "jaspGraphs",
@@ -5246,11 +5247,11 @@
       ],
       "Roxygen": "list(markdown = TRUE)",
       "RemoteType": "github",
-      "RemoteHost": "api.github.com",
       "RemoteUsername": "jasp-stats",
       "RemoteRepo": "jaspGraphs",
       "RemoteRef": "master",
-      "RemoteSha": "1eb48e7e0fe9559bbd15da25f30703c7cca246bb"
+      "RemoteSha": "512b08e7d9a59086face0569626268eca3f3087c",
+      "RemoteHost": "api.github.com"
     },
     "jaspRegression": {
       "Package": "jaspRegression",
@@ -5334,7 +5335,7 @@
       "RemoteUsername": "jasp-stats",
       "RemoteRepo": "jaspTTests",
       "RemoteRef": "master",
-      "RemoteSha": "e7e4ecba502b472d9a9564e4ee67f301143b99ac"
+      "RemoteSha": "c368203c54ebefa68672b9927612e55d142e8f21"
     },
     "jaspTools": {
       "Package": "jaspTools",
@@ -6796,7 +6797,7 @@
     },
     "officer": {
       "Package": "officer",
-      "Version": "0.7.4",
+      "Version": "0.7.5",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Manipulation of Microsoft Word and PowerPoint Documents",
@@ -6834,8 +6835,8 @@
         "withr"
       ],
       "Encoding": "UTF-8",
-      "RoxygenNote": "7.3.3",
       "Collate": "'core_properties.R' 'custom_properties.R' 'defunct.R' 'dev-utils.R' 'docx_add.R' 'docx_comments.R' 'docx_cursor.R' 'docx_embed_font.R' 'docx_part.R' 'docx_replace.R' 'docx_section.R' 'docx_settings.R' 'docx_styles.R' 'docx_utils_funs.R' 'empty_content.R' 'formatting_properties.R' 'fortify_docx.R' 'fortify_pptx.R' 'knitr_utils.R' 'officer.R' 'ooxml.R' 'ooxml_block_objects.R' 'ooxml_run_objects.R' 'openxml_content_type.R' 'openxml_document.R' 'pack_folder.R' 'ph_location.R' 'post-proc.R' 'ppt_class_dir_collection.R' 'ppt_classes.R' 'ppt_notes.R' 'ppt_ph_dedupe_layout.R' 'ppt_ph_manipulate.R' 'ppt_ph_rename_layout.R' 'ppt_ph_with_methods.R' 'pptx_informations.R' 'pptx_layout_helper.R' 'pptx_matrix.R' 'utils.R' 'pptx_slide_manip.R' 'read_docx.R' 'docx_write.R' 'read_docx_styles.R' 'read_pptx.R' 'read_xlsx.R' 'relationship.R' 'rtf.R' 'shape_properties.R' 'shorcuts.R' 'docx_append_context.R' 'utils-xml.R' 'deprecated.R' 'zzz.R'",
+      "Config/roxygen2/version": "8.0.0",
       "NeedsCompilation": "no",
       "Author": "David Gohel [aut, cre], Stefan Moog [aut], Mark Heckmann [aut] (ORCID: <https://orcid.org/0000-0002-0736-7417>), ArData [cph], Frank Hangler [ctb] (function body_replace_all_text), Liz Sander [ctb] (several documentation fixes), Anton Victorson [ctb] (fixes xml structures), Jon Calder [ctb] (update vignettes), John Harrold [ctb] (function annotate_base), John Muschelli [ctb] (google doc compatibility), Bill Denney [ctb] (ORCID: <https://orcid.org/0000-0002-5759-428X>, function as.matrix.rpptx), Nikolai Beck [ctb] (set speaker notes for .pptx documents), Greg Leleu [ctb] (fields functionality in ppt), Majid Eismann [ctb], Wahiduzzaman Khan [ctb] (vectorization of remove_slide), Hongyuan Jia [ctb] (ORCID: <https://orcid.org/0000-0002-0075-8183>), Michael Stackhouse [ctb]",
       "Maintainer": "David Gohel <david.gohel@ardata.fr>",
@@ -6876,7 +6877,7 @@
     },
     "openssl": {
       "Package": "openssl",
-      "Version": "2.4.0",
+      "Version": "2.4.1",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Toolkit for Encryption, Signatures and Certificates Based on OpenSSL",
@@ -7118,7 +7119,7 @@
     },
     "parameters": {
       "Package": "parameters",
-      "Version": "0.28.3",
+      "Version": "0.29.0",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Processing of Model Parameters",
@@ -7133,8 +7134,8 @@
       ],
       "Imports": [
         "bayestestR (>= 0.17.0)",
-        "datawizard (>= 1.3.0)",
-        "insight (>= 1.4.2)",
+        "datawizard (>= 1.3.1)",
+        "insight (>= 1.5.0)",
         "graphics",
         "methods",
         "stats",
@@ -7147,6 +7148,7 @@
         "BayesFactor (>= 0.9.12-4.7)",
         "BayesFM",
         "bbmle",
+        "BSDA",
         "betareg",
         "BH",
         "biglm",
@@ -7203,6 +7205,7 @@
         "ivreg",
         "knitr",
         "lavaan",
+        "lavaan.mi",
         "lcmm",
         "lfe",
         "lm.beta",
@@ -7462,7 +7465,7 @@
     },
     "performance": {
       "Package": "performance",
-      "Version": "0.16.0",
+      "Version": "0.17.0",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Assessment of Regression Models Performance",
@@ -7477,8 +7480,8 @@
       ],
       "Imports": [
         "bayestestR (>= 0.17.0)",
-        "insight (>= 1.4.4)",
-        "datawizard (>= 1.3.0)",
+        "insight (>= 1.5.0)",
+        "datawizard (>= 1.3.1)",
         "stats",
         "methods",
         "utils"
@@ -7564,11 +7567,11 @@
       ],
       "Encoding": "UTF-8",
       "Language": "en-US",
-      "RoxygenNote": "7.3.3",
       "Config/testthat/edition": "3",
       "Config/testthat/parallel": "true",
       "Config/Needs/website": "rstudio/bslib, r-lib/pkgdown, easystats/easystatstemplate",
       "Config/rcmdcheck/ignore-inconsequential-notes": "true",
+      "Config/roxygen2/version": "8.0.0",
       "NeedsCompilation": "no",
       "Author": "Daniel Lüdecke [aut, cre] (ORCID: <https://orcid.org/0000-0002-8895-3206>), Dominique Makowski [aut, ctb] (ORCID: <https://orcid.org/0000-0001-5375-9967>), Mattan S. Ben-Shachar [aut, ctb] (ORCID: <https://orcid.org/0000-0002-4287-4801>), Indrajeet Patil [aut, ctb] (ORCID: <https://orcid.org/0000-0003-1995-6531>), Philip Waggoner [aut, ctb] (ORCID: <https://orcid.org/0000-0002-7825-7573>), Brenton M. Wiernik [aut, ctb] (ORCID: <https://orcid.org/0000-0001-9560-6336>), Rémi Thériault [aut, ctb] (ORCID: <https://orcid.org/0000-0003-4315-6788>), Vincent Arel-Bundock [ctb] (ORCID: <https://orcid.org/0000-0003-2042-7063>), Martin Jullum [rev], gjo11 [rev], Etienne Bacher [ctb] (ORCID: <https://orcid.org/0000-0002-9271-5075>), Joseph Luchman [ctb] (ORCID: <https://orcid.org/0000-0002-8886-9717>)",
       "Repository": "CRAN"
@@ -8679,7 +8682,7 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "1.2.2",
+      "Version": "1.2.3",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Project Environments",
@@ -9468,9 +9471,9 @@
     },
     "statmod": {
       "Package": "statmod",
-      "Version": "1.5.1",
+      "Version": "1.5.2",
       "Source": "Repository",
-      "Date": "2025-10-08",
+      "Date": "2026-05-17",
       "Title": "Statistical Modeling",
       "Authors@R": "c(person(given = \"Gordon\", family = \"Smyth\", role = c(\"cre\", \"aut\"), email = \"smyth@wehi.edu.au\"), person(given = \"Lizhong\", family = \"Chen\", role = \"aut\"), person(given = \"Yifang\", family = \"Hu\", role = \"ctb\"), person(given = \"Peter\", family = \"Dunn\", role = \"ctb\"), person(given = \"Belinda\", family = \"Phipson\", role = \"ctb\"), person(given = \"Yunshun\", family = \"Chen\", role = \"ctb\"))",
       "Maintainer": "Gordon Smyth <smyth@wehi.edu.au>",

--- a/renv.lock
+++ b/renv.lock
@@ -428,10 +428,10 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.1.1",
+      "Version": "1.1.1-1.1",
       "Source": "Repository",
       "Title": "Seamless R and C++ Integration",
-      "Date": "2026-01-07",
+      "Date": "2026-04-19",
       "Authors@R": "c(person(\"Dirk\", \"Eddelbuettel\", role = c(\"aut\", \"cre\"), email = \"edd@debian.org\", comment = c(ORCID = \"0000-0001-6419-907X\")), person(\"Romain\", \"Francois\", role = \"aut\", comment = c(ORCID = \"0000-0002-2444-4226\")), person(\"JJ\", \"Allaire\", role = \"aut\", comment = c(ORCID = \"0000-0003-0174-9868\")), person(\"Kevin\", \"Ushey\", role = \"aut\", comment = c(ORCID = \"0000-0003-2880-7407\")), person(\"Qiang\", \"Kou\", role = \"aut\", comment = c(ORCID = \"0000-0001-6786-5453\")), person(\"Nathan\", \"Russell\", role = \"aut\"), person(\"Iñaki\", \"Ucar\", role = \"aut\", comment = c(ORCID = \"0000-0001-6403-5550\")), person(\"Doug\", \"Bates\", role = \"aut\", comment = c(ORCID = \"0000-0001-8316-9503\")), person(\"John\", \"Chambers\", role = \"aut\"))",
       "Description": "The 'Rcpp' package provides R functions as well as C++ classes which offer a seamless integration of R and C++. Many R data types and objects can be mapped back and forth to C++ equivalents which facilitates both writing of new code as well as easier integration of third-party libraries. Documentation about 'Rcpp' is provided by several vignettes included in this package, via the 'Rcpp Gallery' site at <https://gallery.rcpp.org>, the paper by Eddelbuettel and Francois (2011, <doi:10.18637/jss.v040.i08>), the book by Eddelbuettel (2013, <doi:10.1007/978-1-4614-6868-4>) and the paper by Eddelbuettel and Balamuta (2018, <doi:10.1080/00031305.2017.1375990>); see 'citation(\"Rcpp\")' for details.",
       "Depends": [
@@ -461,13 +461,13 @@
     },
     "RcppArmadillo": {
       "Package": "RcppArmadillo",
-      "Version": "15.2.4-1",
+      "Version": "15.2.6-1",
       "Source": "Repository",
       "Type": "Package",
       "Title": "'Rcpp' Integration for the 'Armadillo' Templated Linear Algebra Library",
-      "Date": "2026-03-17",
+      "Date": "2026-04-20",
       "Authors@R": "c(person(\"Dirk\", \"Eddelbuettel\", role = c(\"aut\", \"cre\"), email = \"edd@debian.org\", comment = c(ORCID = \"0000-0001-6419-907X\")), person(\"Romain\", \"Francois\", role = \"aut\", comment = c(ORCID = \"0000-0002-2444-4226\")), person(\"Doug\", \"Bates\", role = \"aut\", comment = c(ORCID = \"0000-0001-8316-9503\")), person(\"Binxiang\", \"Ni\", role = \"aut\"), person(\"Conrad\", \"Sanderson\", role = \"aut\", comment = c(ORCID = \"0000-0002-0049-4501\")))",
-      "Description": "'Armadillo' is a templated C++ linear algebra library aiming towards a good balance between speed and ease of use. It provides high-level syntax and functionality deliberately similar to Matlab. It is useful for algorithm development directly in C++, or quick conversion of research code into production environments. It provides efficient classes for vectors, matrices and cubes where dense and sparse matrices are supported. Integer, floating point and complex numbers are supported. A sophisticated expression evaluator (based on template meta-programming) automatically combines several operations to increase speed and efficiency. Dynamic evaluation automatically chooses optimal code paths based on detected matrix structures. Matrix decompositions are provided through integration with LAPACK, or one of its high performance drop-in replacements (such as 'MKL' or 'OpenBLAS'). It can automatically use 'OpenMP' multi-threading (parallelisation) to speed up computationally expensive operations. . The 'RcppArmadillo' package includes the header files from the 'Armadillo' library; users do not need to install 'Armadillo' itself in order to use 'RcppArmadillo'. Starting from release 15.0.0, the minimum compilation standard is C++14 so 'Armadillo' version 14.6.3 is included as a fallback when an R package forces the C++11 standard. Package authors should set a '#define' to select the 'current' version, or select the 'legacy' version (also chosen as default) if they must. See 'GitHub issue #475' for details. . Since release 7.800.0, 'Armadillo' is licensed under Apache License 2; previous releases were under licensed as MPL 2.0 from version 3.800.0 onwards and LGPL-3 prior to that; 'RcppArmadillo' (the 'Rcpp' bindings/bridge to Armadillo) is licensed under the GNU GPL version 2 or later, as is the rest of 'Rcpp'.",
+      "Description": "'Armadillo' is a templated C++ linear algebra library aiming towards a good balance between speed and ease of use. It provides high-level syntax and functionality deliberately similar to Matlab. It is useful for algorithm development directly in C++, or quick conversion of research code into production environments. It provides efficient classes for vectors, matrices and cubes where dense and sparse matrices are supported. Integer, floating point and complex numbers are supported. A sophisticated expression evaluator (based on template meta-programming) automatically combines several operations to increase speed and efficiency. Dynamic evaluation automatically chooses optimal code paths based on detected matrix structures. Matrix decompositions are provided through integration with LAPACK, or one of its high performance drop-in replacements (such as 'MKL' or 'OpenBLAS'). It can automatically use 'OpenMP' multi-threading (parallelisation) to speed up computationally expensive operations. . The 'RcppArmadillo' package includes the header files from the 'Armadillo' library; users do not need to install 'Armadillo' itself in order to use 'RcppArmadillo'. Starting from release 15.0.0, the minimum compilation standard is C++14. . Since release 7.800.0, 'Armadillo' is licensed under Apache License 2; previous releases were under licensed as MPL 2.0 from version 3.800.0 onwards and LGPL-3 prior to that; 'RcppArmadillo' (the 'Rcpp' bindings/bridge to Armadillo) is licensed under the GNU GPL version 2 or later, as is the rest of 'Rcpp'.",
       "License": "GPL (>= 2)",
       "LazyLoad": "yes",
       "Depends": [
@@ -477,7 +477,7 @@
         "Rcpp"
       ],
       "Imports": [
-        "Rcpp (>= 1.0.12)",
+        "Rcpp (>= 1.1.1)",
         "stats",
         "utils",
         "methods"
@@ -492,6 +492,8 @@
       "URL": "https://github.com/RcppCore/RcppArmadillo, https://dirk.eddelbuettel.com/code/rcpp.armadillo.html",
       "BugReports": "https://github.com/RcppCore/RcppArmadillo/issues",
       "RoxygenNote": "6.0.1",
+      "Encoding": "UTF-8",
+      "VignetteBuilder": "Rcpp",
       "NeedsCompilation": "yes",
       "Author": "Dirk Eddelbuettel [aut, cre] (ORCID: <https://orcid.org/0000-0001-6419-907X>), Romain Francois [aut] (ORCID: <https://orcid.org/0000-0002-2444-4226>), Doug Bates [aut] (ORCID: <https://orcid.org/0000-0001-8316-9503>), Binxiang Ni [aut], Conrad Sanderson [aut] (ORCID: <https://orcid.org/0000-0002-0049-4501>)",
       "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
@@ -571,7 +573,7 @@
     },
     "S7": {
       "Package": "S7",
-      "Version": "0.2.1",
+      "Version": "0.2.2",
       "Source": "Repository",
       "Title": "An Object Oriented System Meant to Become a Successor to S3 and S4",
       "Authors@R": "c( person(\"Object-Oriented Programming Working Group\", role = \"cph\"), person(\"Davis\", \"Vaughan\", role = \"aut\"), person(\"Jim\", \"Hester\", role = \"aut\", comment = c(ORCID = \"0000-0002-2739-7082\")), person(\"Tomasz\", \"Kalinowski\", role = \"aut\"), person(\"Will\", \"Landau\", role = \"aut\"), person(\"Michael\", \"Lawrence\", role = \"aut\"), person(\"Martin\", \"Maechler\", role = \"aut\", comment = c(ORCID = \"0000-0002-8685-9910\")), person(\"Luke\", \"Tierney\", role = \"aut\"), person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = c(\"aut\", \"cre\"), comment = c(ORCID = \"0000-0003-4757-117X\")) )",
@@ -1068,35 +1070,37 @@
     },
     "bit64": {
       "Package": "bit64",
-      "Version": "4.6.0-1",
+      "Version": "4.8.0",
       "Source": "Repository",
       "Title": "A S3 Class for Vectors of 64bit Integers",
-      "Authors@R": "c( person(\"Michael\", \"Chirico\", email = \"michaelchirico4@gmail.com\", role = c(\"aut\", \"cre\")), person(\"Jens\", \"Oehlschlägel\", role = \"aut\"), person(\"Leonardo\", \"Silvestri\", role = \"ctb\"), person(\"Ofek\", \"Shilon\", role = \"ctb\") )",
+      "Authors@R": "c( person(\"Michael\", \"Chirico\", email=\"michaelchirico4@gmail.com\", role=c(\"aut\", \"cre\")), person(\"Jens\", \"Oehlschlägel\", role=\"aut\"), person(\"Leonardo\", \"Silvestri\", role=\"ctb\"), person(\"Ofek\", \"Shilon\", role=\"ctb\"), person(\"Christian\", \"Ullerich\", role=\"ctb\") )",
       "Depends": [
-        "R (>= 3.4.0)",
-        "bit (>= 4.0.0)"
+        "R (>= 3.5.0)"
       ],
       "Description": "Package 'bit64' provides serializable S3 atomic 64bit (signed) integers. These are useful for handling database keys and exact counting in +-2^63. WARNING: do not use them as replacement for 32bit integers, integer64 are not supported for subscripting by R-core and they have different semantics when combined with double, e.g. integer64 + double => integer64. Class integer64 can be used in vectors, matrices, arrays and data.frames. Methods are available for coercion from and to logicals, integers, doubles, characters and factors as well as many elementwise and summary functions. Many fast algorithmic operations such as 'match' and 'order' support inter- active data exploration and manipulation and optionally leverage caching.",
       "License": "GPL-2 | GPL-3",
       "LazyLoad": "yes",
       "ByteCompile": "yes",
-      "URL": "https://github.com/r-lib/bit64",
+      "URL": "https://github.com/r-lib/bit64, https://bit64.r-lib.org",
       "Encoding": "UTF-8",
       "Imports": [
+        "bit (>= 4.0.0)",
         "graphics",
         "methods",
         "stats",
         "utils"
       ],
       "Suggests": [
-        "testthat (>= 3.0.3)",
+        "patrick (>= 0.3.0)",
+        "testthat (>= 3.3.0)",
         "withr"
       ],
       "Config/testthat/edition": "3",
-      "Config/needs/development": "testthat",
-      "RoxygenNote": "7.3.2",
+      "Config/Needs/development": "patrick, testthat",
+      "Config/Needs/website": "tidyverse/tidytemplate",
+      "RoxygenNote": "7.3.3",
       "NeedsCompilation": "yes",
-      "Author": "Michael Chirico [aut, cre], Jens Oehlschlägel [aut], Leonardo Silvestri [ctb], Ofek Shilon [ctb]",
+      "Author": "Michael Chirico [aut, cre], Jens Oehlschlägel [aut], Leonardo Silvestri [ctb], Ofek Shilon [ctb], Christian Ullerich [ctb]",
       "Maintainer": "Michael Chirico <michaelchirico4@gmail.com>",
       "Repository": "CRAN"
     },
@@ -1961,7 +1965,7 @@
     },
     "cpp11": {
       "Package": "cpp11",
-      "Version": "0.5.4",
+      "Version": "0.5.5",
       "Source": "Repository",
       "Title": "A C++11 Interface for R's C Interface",
       "Authors@R": "c( person(\"Davis\", \"Vaughan\", email = \"davis@posit.co\", role = c(\"aut\", \"cre\"), comment = c(ORCID = \"0000-0003-4777-038X\")), person(\"Jim\",\"Hester\", role = \"aut\", comment = c(ORCID = \"0000-0002-2739-7082\")), person(\"Romain\", \"François\", role = \"aut\", comment = c(ORCID = \"0000-0002-2444-4226\")), person(\"Benjamin\", \"Kietzman\", role = \"ctb\"), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")) )",
@@ -2103,7 +2107,7 @@
     },
     "curl": {
       "Package": "curl",
-      "Version": "7.0.0",
+      "Version": "7.1.0",
       "Source": "Repository",
       "Type": "Package",
       "Title": "A Modern and Flexible Web Client for R",
@@ -2137,7 +2141,7 @@
     },
     "data.table": {
       "Package": "data.table",
-      "Version": "1.18.2.1",
+      "Version": "1.18.4",
       "Source": "Repository",
       "Title": "Extension of `data.frame`",
       "Depends": [
@@ -2163,15 +2167,15 @@
       "VignetteBuilder": "knitr",
       "Encoding": "UTF-8",
       "ByteCompile": "TRUE",
-      "Authors@R": "c( person(\"Tyson\",\"Barrett\",        role=c(\"aut\",\"cre\"), email=\"t.barrett88@gmail.com\", comment = c(ORCID=\"0000-0002-2137-1391\")), person(\"Matt\",\"Dowle\",           role=\"aut\",          email=\"mattjdowle@gmail.com\"), person(\"Arun\",\"Srinivasan\",      role=\"aut\",          email=\"asrini@pm.me\"), person(\"Jan\",\"Gorecki\",          role=\"aut\",          email=\"j.gorecki@wit.edu.pl\"), person(\"Michael\",\"Chirico\",      role=\"aut\",          email=\"michaelchirico4@gmail.com\", comment = c(ORCID=\"0000-0003-0787-087X\")), person(\"Toby\",\"Hocking\",         role=\"aut\",          email=\"toby.hocking@r-project.org\", comment = c(ORCID=\"0000-0002-3146-0865\")), person(\"Benjamin\",\"Schwendinger\",role=\"aut\", comment = c(ORCID=\"0000-0003-3315-8114\")), person(\"Ivan\", \"Krylov\",         role=\"aut\",          email=\"ikrylov@disroot.org\",   comment = c(ORCID=\"0000-0002-0172-3812\")), person(\"Pasha\",\"Stetsenko\",      role=\"ctb\"), person(\"Tom\",\"Short\",            role=\"ctb\"), person(\"Steve\",\"Lianoglou\",      role=\"ctb\"), person(\"Eduard\",\"Antonyan\",      role=\"ctb\"), person(\"Markus\",\"Bonsch\",        role=\"ctb\"), person(\"Hugh\",\"Parsonage\",       role=\"ctb\"), person(\"Scott\",\"Ritchie\",        role=\"ctb\"), person(\"Kun\",\"Ren\",              role=\"ctb\"), person(\"Xianying\",\"Tan\",         role=\"ctb\"), person(\"Rick\",\"Saporta\",         role=\"ctb\"), person(\"Otto\",\"Seiskari\",        role=\"ctb\"), person(\"Xianghui\",\"Dong\",        role=\"ctb\"), person(\"Michel\",\"Lang\",          role=\"ctb\"), person(\"Watal\",\"Iwasaki\",        role=\"ctb\"), person(\"Seth\",\"Wenchel\",         role=\"ctb\"), person(\"Karl\",\"Broman\",          role=\"ctb\"), person(\"Tobias\",\"Schmidt\",       role=\"ctb\"), person(\"David\",\"Arenburg\",       role=\"ctb\"), person(\"Ethan\",\"Smith\",          role=\"ctb\"), person(\"Francois\",\"Cocquemas\",   role=\"ctb\"), person(\"Matthieu\",\"Gomez\",       role=\"ctb\"), person(\"Philippe\",\"Chataignon\",  role=\"ctb\"), person(\"Nello\",\"Blaser\",         role=\"ctb\"), person(\"Dmitry\",\"Selivanov\",     role=\"ctb\"), person(\"Andrey\",\"Riabushenko\",   role=\"ctb\"), person(\"Cheng\",\"Lee\",            role=\"ctb\"), person(\"Declan\",\"Groves\",        role=\"ctb\"), person(\"Daniel\",\"Possenriede\",   role=\"ctb\"), person(\"Felipe\",\"Parages\",       role=\"ctb\"), person(\"Denes\",\"Toth\",           role=\"ctb\"), person(\"Mus\",\"Yaramaz-David\",    role=\"ctb\"), person(\"Ayappan\",\"Perumal\",      role=\"ctb\"), person(\"James\",\"Sams\",           role=\"ctb\"), person(\"Martin\",\"Morgan\",        role=\"ctb\"), person(\"Michael\",\"Quinn\",        role=\"ctb\"), person(given=\"@javrucebo\",       role=\"ctb\", comment=\"GitHub user\"), person(\"Marc\",\"Halperin\",        role=\"ctb\"), person(\"Roy\",\"Storey\",           role=\"ctb\"), person(\"Manish\",\"Saraswat\",      role=\"ctb\"), person(\"Morgan\",\"Jacob\",         role=\"ctb\"), person(\"Michael\",\"Schubmehl\",    role=\"ctb\"), person(\"Davis\",\"Vaughan\",        role=\"ctb\"), person(\"Leonardo\",\"Silvestri\",   role=\"ctb\"), person(\"Jim\",\"Hester\",           role=\"ctb\"), person(\"Anthony\",\"Damico\",       role=\"ctb\"), person(\"Sebastian\",\"Freundt\",    role=\"ctb\"), person(\"David\",\"Simons\",         role=\"ctb\"), person(\"Elliott\",\"Sales de Andrade\", role=\"ctb\"), person(\"Cole\",\"Miller\",          role=\"ctb\"), person(\"Jens Peder\",\"Meldgaard\", role=\"ctb\"), person(\"Vaclav\",\"Tlapak\",        role=\"ctb\"), person(\"Kevin\",\"Ushey\",          role=\"ctb\"), person(\"Dirk\",\"Eddelbuettel\",    role=\"ctb\"), person(\"Tony\",\"Fischetti\",       role=\"ctb\"), person(\"Ofek\",\"Shilon\",          role=\"ctb\"), person(\"Vadim\",\"Khotilovich\",    role=\"ctb\"), person(\"Hadley\",\"Wickham\",       role=\"ctb\"), person(\"Bennet\",\"Becker\",        role=\"ctb\"), person(\"Kyle\",\"Haynes\",          role=\"ctb\"), person(\"Boniface Christian\",\"Kamgang\", role=\"ctb\"), person(\"Olivier\",\"Delmarcell\",   role=\"ctb\"), person(\"Josh\",\"O'Brien\",         role=\"ctb\"), person(\"Dereck\",\"de Mezquita\",   role=\"ctb\"), person(\"Michael\",\"Czekanski\",    role=\"ctb\"), person(\"Dmitry\", \"Shemetov\",     role=\"ctb\"), person(\"Nitish\", \"Jha\",          role=\"ctb\"), person(\"Joshua\", \"Wu\",           role=\"ctb\"), person(\"Iago\", \"Giné-Vázquez\",   role=\"ctb\"), person(\"Anirban\", \"Chetia\",      role=\"ctb\"), person(\"Doris\", \"Amoakohene\",    role=\"ctb\"), person(\"Angel\", \"Feliz\",         role=\"ctb\"), person(\"Michael\",\"Young\",        role=\"ctb\"), person(\"Mark\", \"Seeto\",          role=\"ctb\"), person(\"Philippe\", \"Grosjean\",   role=\"ctb\"), person(\"Vincent\", \"Runge\",       role=\"ctb\"), person(\"Christian\", \"Wia\",       role=\"ctb\"), person(\"Elise\", \"Maigné\",        role=\"ctb\"), person(\"Vincent\", \"Rocher\",      role=\"ctb\"), person(\"Vijay\", \"Lulla\",         role=\"ctb\"), person(\"Aljaž\", \"Sluga\",         role=\"ctb\"), person(\"Bill\", \"Evans\",          role=\"ctb\"), person(\"Reino\", \"Bruner\",        role=\"ctb\"), person(given=\"@badasahog\",       role=\"ctb\", comment=\"GitHub user\"), person(\"Vinit\", \"Thakur\",        role=\"ctb\"), person(\"Mukul\", \"Kumar\",         role=\"ctb\"), person(\"Ildikó\", \"Czeller\",      role=\"ctb\"), person(\"Manmita\", \"Das\",         role=\"ctb\") )",
+      "Authors@R": "c( person(\"Tyson\",\"Barrett\",        role=c(\"aut\",\"cre\"), email=\"t.barrett88@gmail.com\", comment = c(ORCID=\"0000-0002-2137-1391\")), person(\"Matt\",\"Dowle\",           role=\"aut\",          email=\"mattjdowle@gmail.com\"), person(\"Arun\",\"Srinivasan\",      role=\"aut\",          email=\"asrini@pm.me\"), person(\"Jan\",\"Gorecki\",          role=\"aut\",          email=\"j.gorecki@wit.edu.pl\"), person(\"Michael\",\"Chirico\",      role=\"aut\",          email=\"michaelchirico4@gmail.com\", comment = c(ORCID=\"0000-0003-0787-087X\")), person(\"Toby\",\"Hocking\",         role=\"aut\",          email=\"toby.hocking@r-project.org\", comment = c(ORCID=\"0000-0002-3146-0865\")), person(\"Benjamin\",\"Schwendinger\",role=\"aut\", comment = c(ORCID=\"0000-0003-3315-8114\")), person(\"Ivan\", \"Krylov\",         role=\"aut\",          email=\"ikrylov@disroot.org\",   comment = c(ORCID=\"0000-0002-0172-3812\")), person(\"Pasha\",\"Stetsenko\",      role=\"ctb\"), person(\"Tom\",\"Short\",            role=\"ctb\"), person(\"Steve\",\"Lianoglou\",      role=\"ctb\"), person(\"Eduard\",\"Antonyan\",      role=\"ctb\"), person(\"Markus\",\"Bonsch\",        role=\"ctb\"), person(\"Hugh\",\"Parsonage\",       role=\"ctb\"), person(\"Scott\",\"Ritchie\",        role=\"ctb\"), person(\"Kun\",\"Ren\",              role=\"ctb\"), person(\"Xianying\",\"Tan\",         role=\"ctb\"), person(\"Rick\",\"Saporta\",         role=\"ctb\"), person(\"Otto\",\"Seiskari\",        role=\"ctb\"), person(\"Xianghui\",\"Dong\",        role=\"ctb\"), person(\"Michel\",\"Lang\",          role=\"ctb\"), person(\"Watal\",\"Iwasaki\",        role=\"ctb\"), person(\"Seth\",\"Wenchel\",         role=\"ctb\"), person(\"Karl\",\"Broman\",          role=\"ctb\"), person(\"Tobias\",\"Schmidt\",       role=\"ctb\"), person(\"David\",\"Arenburg\",       role=\"ctb\"), person(\"Ethan\",\"Smith\",          role=\"ctb\"), person(\"Francois\",\"Cocquemas\",   role=\"ctb\"), person(\"Matthieu\",\"Gomez\",       role=\"ctb\"), person(\"Philippe\",\"Chataignon\",  role=\"ctb\"), person(\"Nello\",\"Blaser\",         role=\"ctb\"), person(\"Dmitry\",\"Selivanov\",     role=\"ctb\"), person(\"Andrey\",\"Riabushenko\",   role=\"ctb\"), person(\"Cheng\",\"Lee\",            role=\"ctb\"), person(\"Declan\",\"Groves\",        role=\"ctb\"), person(\"Daniel\",\"Possenriede\",   role=\"ctb\"), person(\"Felipe\",\"Parages\",       role=\"ctb\"), person(\"Denes\",\"Toth\",           role=\"ctb\"), person(\"Mus\",\"Yaramaz-David\",    role=\"ctb\"), person(\"Ayappan\",\"Perumal\",      role=\"ctb\"), person(\"James\",\"Sams\",           role=\"ctb\"), person(\"Martin\",\"Morgan\",        role=\"ctb\"), person(\"Michael\",\"Quinn\",        role=\"ctb\"), person(given=\"@javrucebo\",       role=\"ctb\", comment=\"GitHub user\"), person(\"Marc\",\"Halperin\",        role=\"ctb\"), person(\"Roy\",\"Storey\",           role=\"ctb\"), person(\"Manish\",\"Saraswat\",      role=\"ctb\"), person(\"Morgan\",\"Jacob\",         role=\"ctb\"), person(\"Michael\",\"Schubmehl\",    role=\"ctb\"), person(\"Davis\",\"Vaughan\",        role=\"ctb\"), person(\"Leonardo\",\"Silvestri\",   role=\"ctb\"), person(\"Jim\",\"Hester\",           role=\"ctb\"), person(\"Anthony\",\"Damico\",       role=\"ctb\"), person(\"Sebastian\",\"Freundt\",    role=\"ctb\"), person(\"David\",\"Simons\",         role=\"ctb\"), person(\"Elliott\",\"Sales de Andrade\", role=\"ctb\"), person(\"Cole\",\"Miller\",          role=\"ctb\"), person(\"Jens Peder\",\"Meldgaard\", role=\"ctb\"), person(\"Vaclav\",\"Tlapak\",        role=\"ctb\"), person(\"Kevin\",\"Ushey\",          role=\"ctb\"), person(\"Dirk\",\"Eddelbuettel\",    role=\"ctb\"), person(\"Tony\",\"Fischetti\",       role=\"ctb\"), person(\"Ofek\",\"Shilon\",          role=\"ctb\"), person(\"Vadim\",\"Khotilovich\",    role=\"ctb\"), person(\"Hadley\",\"Wickham\",       role=\"ctb\"), person(\"Bennet\",\"Becker\",        role=\"ctb\"), person(\"Kyle\",\"Haynes\",          role=\"ctb\"), person(\"Boniface Christian\",\"Kamgang\", role=\"ctb\"), person(\"Olivier\",\"Delmarcell\",   role=\"ctb\"), person(\"Josh\",\"O'Brien\",         role=\"ctb\"), person(\"Dereck\",\"de Mezquita\",   role=\"ctb\"), person(\"Michael\",\"Czekanski\",    role=\"ctb\"), person(\"Dmitry\", \"Shemetov\",     role=\"ctb\"), person(\"Nitish\", \"Jha\",          role=\"ctb\"), person(\"Joshua\", \"Wu\",           role=\"ctb\"), person(\"Iago\", \"Giné-Vázquez\",   role=\"ctb\"), person(\"Anirban\", \"Chetia\",      role=\"ctb\"), person(\"Doris\", \"Amoakohene\",    role=\"ctb\"), person(\"Angel\", \"Feliz\",         role=\"ctb\"), person(\"Michael\",\"Young\",        role=\"ctb\"), person(\"Mark\", \"Seeto\",          role=\"ctb\"), person(\"Philippe\", \"Grosjean\",   role=\"ctb\"), person(\"Vincent\", \"Runge\",       role=\"ctb\"), person(\"Christian\", \"Wia\",       role=\"ctb\"), person(\"Elise\", \"Maigné\",        role=\"ctb\"), person(\"Vincent\", \"Rocher\",      role=\"ctb\"), person(\"Vijay\", \"Lulla\",         role=\"ctb\"), person(\"Aljaž\", \"Sluga\",         role=\"ctb\"), person(\"Bill\", \"Evans\",          role=\"ctb\"), person(\"Reino\", \"Bruner\",        role=\"ctb\"), person(given=\"@badasahog\",       role=\"ctb\", comment=\"GitHub user\"), person(\"Vinit\", \"Thakur\",        role=\"ctb\"), person(\"Mukul\", \"Kumar\",         role=\"ctb\"), person(\"Ildikó\", \"Czeller\",      role=\"ctb\"), person(\"Manmita\", \"Das\",         role=\"ctb\"), person(\"Tarun\", \"Thammisetty\",   role=\"ctb\") )",
       "NeedsCompilation": "yes",
-      "Author": "Tyson Barrett [aut, cre] (ORCID: <https://orcid.org/0000-0002-2137-1391>), Matt Dowle [aut], Arun Srinivasan [aut], Jan Gorecki [aut], Michael Chirico [aut] (ORCID: <https://orcid.org/0000-0003-0787-087X>), Toby Hocking [aut] (ORCID: <https://orcid.org/0000-0002-3146-0865>), Benjamin Schwendinger [aut] (ORCID: <https://orcid.org/0000-0003-3315-8114>), Ivan Krylov [aut] (ORCID: <https://orcid.org/0000-0002-0172-3812>), Pasha Stetsenko [ctb], Tom Short [ctb], Steve Lianoglou [ctb], Eduard Antonyan [ctb], Markus Bonsch [ctb], Hugh Parsonage [ctb], Scott Ritchie [ctb], Kun Ren [ctb], Xianying Tan [ctb], Rick Saporta [ctb], Otto Seiskari [ctb], Xianghui Dong [ctb], Michel Lang [ctb], Watal Iwasaki [ctb], Seth Wenchel [ctb], Karl Broman [ctb], Tobias Schmidt [ctb], David Arenburg [ctb], Ethan Smith [ctb], Francois Cocquemas [ctb], Matthieu Gomez [ctb], Philippe Chataignon [ctb], Nello Blaser [ctb], Dmitry Selivanov [ctb], Andrey Riabushenko [ctb], Cheng Lee [ctb], Declan Groves [ctb], Daniel Possenriede [ctb], Felipe Parages [ctb], Denes Toth [ctb], Mus Yaramaz-David [ctb], Ayappan Perumal [ctb], James Sams [ctb], Martin Morgan [ctb], Michael Quinn [ctb], @javrucebo [ctb] (GitHub user), Marc Halperin [ctb], Roy Storey [ctb], Manish Saraswat [ctb], Morgan Jacob [ctb], Michael Schubmehl [ctb], Davis Vaughan [ctb], Leonardo Silvestri [ctb], Jim Hester [ctb], Anthony Damico [ctb], Sebastian Freundt [ctb], David Simons [ctb], Elliott Sales de Andrade [ctb], Cole Miller [ctb], Jens Peder Meldgaard [ctb], Vaclav Tlapak [ctb], Kevin Ushey [ctb], Dirk Eddelbuettel [ctb], Tony Fischetti [ctb], Ofek Shilon [ctb], Vadim Khotilovich [ctb], Hadley Wickham [ctb], Bennet Becker [ctb], Kyle Haynes [ctb], Boniface Christian Kamgang [ctb], Olivier Delmarcell [ctb], Josh O'Brien [ctb], Dereck de Mezquita [ctb], Michael Czekanski [ctb], Dmitry Shemetov [ctb], Nitish Jha [ctb], Joshua Wu [ctb], Iago Giné-Vázquez [ctb], Anirban Chetia [ctb], Doris Amoakohene [ctb], Angel Feliz [ctb], Michael Young [ctb], Mark Seeto [ctb], Philippe Grosjean [ctb], Vincent Runge [ctb], Christian Wia [ctb], Elise Maigné [ctb], Vincent Rocher [ctb], Vijay Lulla [ctb], Aljaž Sluga [ctb], Bill Evans [ctb], Reino Bruner [ctb], @badasahog [ctb] (GitHub user), Vinit Thakur [ctb], Mukul Kumar [ctb], Ildikó Czeller [ctb], Manmita Das [ctb]",
+      "Author": "Tyson Barrett [aut, cre] (ORCID: <https://orcid.org/0000-0002-2137-1391>), Matt Dowle [aut], Arun Srinivasan [aut], Jan Gorecki [aut], Michael Chirico [aut] (ORCID: <https://orcid.org/0000-0003-0787-087X>), Toby Hocking [aut] (ORCID: <https://orcid.org/0000-0002-3146-0865>), Benjamin Schwendinger [aut] (ORCID: <https://orcid.org/0000-0003-3315-8114>), Ivan Krylov [aut] (ORCID: <https://orcid.org/0000-0002-0172-3812>), Pasha Stetsenko [ctb], Tom Short [ctb], Steve Lianoglou [ctb], Eduard Antonyan [ctb], Markus Bonsch [ctb], Hugh Parsonage [ctb], Scott Ritchie [ctb], Kun Ren [ctb], Xianying Tan [ctb], Rick Saporta [ctb], Otto Seiskari [ctb], Xianghui Dong [ctb], Michel Lang [ctb], Watal Iwasaki [ctb], Seth Wenchel [ctb], Karl Broman [ctb], Tobias Schmidt [ctb], David Arenburg [ctb], Ethan Smith [ctb], Francois Cocquemas [ctb], Matthieu Gomez [ctb], Philippe Chataignon [ctb], Nello Blaser [ctb], Dmitry Selivanov [ctb], Andrey Riabushenko [ctb], Cheng Lee [ctb], Declan Groves [ctb], Daniel Possenriede [ctb], Felipe Parages [ctb], Denes Toth [ctb], Mus Yaramaz-David [ctb], Ayappan Perumal [ctb], James Sams [ctb], Martin Morgan [ctb], Michael Quinn [ctb], @javrucebo [ctb] (GitHub user), Marc Halperin [ctb], Roy Storey [ctb], Manish Saraswat [ctb], Morgan Jacob [ctb], Michael Schubmehl [ctb], Davis Vaughan [ctb], Leonardo Silvestri [ctb], Jim Hester [ctb], Anthony Damico [ctb], Sebastian Freundt [ctb], David Simons [ctb], Elliott Sales de Andrade [ctb], Cole Miller [ctb], Jens Peder Meldgaard [ctb], Vaclav Tlapak [ctb], Kevin Ushey [ctb], Dirk Eddelbuettel [ctb], Tony Fischetti [ctb], Ofek Shilon [ctb], Vadim Khotilovich [ctb], Hadley Wickham [ctb], Bennet Becker [ctb], Kyle Haynes [ctb], Boniface Christian Kamgang [ctb], Olivier Delmarcell [ctb], Josh O'Brien [ctb], Dereck de Mezquita [ctb], Michael Czekanski [ctb], Dmitry Shemetov [ctb], Nitish Jha [ctb], Joshua Wu [ctb], Iago Giné-Vázquez [ctb], Anirban Chetia [ctb], Doris Amoakohene [ctb], Angel Feliz [ctb], Michael Young [ctb], Mark Seeto [ctb], Philippe Grosjean [ctb], Vincent Runge [ctb], Christian Wia [ctb], Elise Maigné [ctb], Vincent Rocher [ctb], Vijay Lulla [ctb], Aljaž Sluga [ctb], Bill Evans [ctb], Reino Bruner [ctb], @badasahog [ctb] (GitHub user), Vinit Thakur [ctb], Mukul Kumar [ctb], Ildikó Czeller [ctb], Manmita Das [ctb], Tarun Thammisetty [ctb]",
       "Maintainer": "Tyson Barrett <t.barrett88@gmail.com>",
       "Repository": "CRAN"
     },
     "datawizard": {
       "Package": "datawizard",
-      "Version": "1.3.0",
+      "Version": "1.3.1",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Easy Data Wrangling and Statistical Transformations",
@@ -2185,7 +2189,7 @@
         "R (>= 4.0)"
       ],
       "Imports": [
-        "insight (>= 1.4.2)",
+        "insight (>= 1.4.6)",
         "stats",
         "utils"
       ],
@@ -2199,6 +2203,7 @@
         "dplyr (>= 1.1)",
         "effectsize",
         "emmeans",
+        "fixest",
         "gamm4",
         "ggplot2 (>= 3.5.0)",
         "gt",
@@ -2209,6 +2214,7 @@
         "mediation",
         "modelbased",
         "nanoparquet",
+        "openssl",
         "parameters (>= 0.21.7)",
         "performance (>= 0.14.0)",
         "poorman (>= 0.2.7)",
@@ -2305,7 +2311,7 @@
     },
     "devtools": {
       "Package": "devtools",
-      "Version": "2.5.0",
+      "Version": "2.5.2",
       "Source": "Repository",
       "Title": "Tools to Make Developing R Packages Easier",
       "Authors@R": "c( person(\"Hadley\", \"Wickham\", role = \"aut\"), person(\"Jim\", \"Hester\", role = \"aut\"), person(\"Winston\", \"Chang\", role = \"aut\"), person(\"Jennifer\", \"Bryan\", , \"jenny@posit.co\", role = c(\"aut\", \"cre\"), comment = c(ORCID = \"0000-0002-6983-2759\")), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"), comment = c(ROR = \"03wc8by49\")) )",
@@ -2318,20 +2324,20 @@
         "usethis (>= 3.2.1)"
       ],
       "Imports": [
-        "cli (>= 3.6.5)",
+        "cli (>= 3.6.6)",
         "desc (>= 1.4.3)",
-        "ellipsis (>= 0.3.2)",
-        "fs (>= 1.6.7)",
+        "ellipsis (>= 0.3.3)",
+        "fs (>= 2.1.0)",
         "lifecycle (>= 1.0.5)",
         "memoise (>= 2.0.1)",
         "miniUI (>= 0.1.2)",
-        "pak (>= 0.9.2)",
+        "pak (>= 0.9.5)",
         "pkgbuild (>= 1.4.8)",
         "pkgdown (>= 2.2.0)",
-        "pkgload (>= 1.5.0)",
+        "pkgload (>= 1.5.2)",
         "profvis (>= 0.4.0)",
         "rcmdcheck (>= 1.4.0)",
-        "rlang (>= 1.1.7)",
+        "rlang (>= 1.2.0)",
         "roxygen2 (>= 7.3.3)",
         "rversions (>= 3.0.0)",
         "sessioninfo (>= 1.2.3)",
@@ -3276,10 +3282,10 @@
     },
     "fracdiff": {
       "Package": "fracdiff",
-      "Version": "1.5-3",
+      "Version": "1.5-4",
       "Source": "Repository",
-      "VersionNote": "Released 1.5-0 on 2019-12-09, 1.5-1 on 2020-01-20, 1.5-2 on 2022-10-31",
-      "Date": "2024-02-01",
+      "VersionNote": "Released 1.5-3 on 2024-02-01, 1.5-2 on 2022-10-31, 1.5-1 on 2020-01-20",
+      "Date": "2026-04-27",
       "Title": "Fractionally Differenced ARIMA aka ARFIMA(P,d,q) Models",
       "Authors@R": "c(person(\"Martin\",\"Maechler\", role=c(\"aut\",\"cre\"), email=\"maechler@stat.math.ethz.ch\", comment = c(ORCID = \"0000-0002-8685-9910\")) , person(\"Chris\", \"Fraley\", role=c(\"ctb\",\"cph\"), comment = \"S original; Fortran code\") , person(\"Friedrich\", \"Leisch\", role = \"ctb\", comment = c(\"R port\", ORCID = \"0000-0001-7278-1983\")) , person(\"Valderio\", \"Reisen\", role=\"ctb\", comment = \"fdGPH() & fdSperio()\") , person(\"Artur\",  \"Lemonte\",  role=\"ctb\", comment = \"fdGPH() & fdSperio()\") , person(\"Rob\", \"Hyndman\", email=\"Rob.Hyndman@monash.edu\", role=\"ctb\", comment = c(\"residuals() & fitted()\", ORCID = \"0000-0002-2140-5352\")) )",
       "Description": "Maximum likelihood estimation of the parameters of a fractionally differenced ARIMA(p,d,q) model (Haslett and Raftery, Appl.Statistics, 1989); including inference and basic methods.  Some alternative algorithms to estimate \"H\".",
@@ -3296,13 +3302,13 @@
       "BugReports": "https://github.com/mmaechler/fracdiff/issues",
       "Encoding": "UTF-8",
       "NeedsCompilation": "yes",
-      "Author": "Martin Maechler [aut, cre] (<https://orcid.org/0000-0002-8685-9910>), Chris Fraley [ctb, cph] (S original; Fortran code), Friedrich Leisch [ctb] (R port, <https://orcid.org/0000-0001-7278-1983>), Valderio Reisen [ctb] (fdGPH() & fdSperio()), Artur Lemonte [ctb] (fdGPH() & fdSperio()), Rob Hyndman [ctb] (residuals() & fitted(), <https://orcid.org/0000-0002-2140-5352>)",
+      "Author": "Martin Maechler [aut, cre] (ORCID: <https://orcid.org/0000-0002-8685-9910>), Chris Fraley [ctb, cph] (S original; Fortran code), Friedrich Leisch [ctb] (R port, ORCID: <https://orcid.org/0000-0001-7278-1983>), Valderio Reisen [ctb] (fdGPH() & fdSperio()), Artur Lemonte [ctb] (fdGPH() & fdSperio()), Rob Hyndman [ctb] (residuals() & fitted(), ORCID: <https://orcid.org/0000-0002-2140-5352>)",
       "Maintainer": "Martin Maechler <maechler@stat.math.ethz.ch>",
       "Repository": "CRAN"
     },
     "fs": {
       "Package": "fs",
-      "Version": "2.0.1",
+      "Version": "2.1.0",
       "Source": "Repository",
       "Title": "Cross-Platform File System Operations Based on 'libuv'",
       "Authors@R": "c( person(\"Jim\", \"Hester\", role = \"aut\"), person(\"Hadley\", \"Wickham\", role = \"aut\"), person(\"Gábor\", \"Csárdi\", role = \"aut\"), person(\"Jeroen\", \"Ooms\", , \"jeroenooms@gmail.com\", role = \"cre\"), person(\"libuv project contributors\", role = \"cph\", comment = \"libuv library\"), person(\"Joyent, Inc. and other Node contributors\", role = \"cph\", comment = \"libuv library\"), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"), comment = c(ROR = \"03wc8by49\")) )",
@@ -3646,7 +3652,7 @@
     },
     "ggplot2": {
       "Package": "ggplot2",
-      "Version": "4.0.2",
+      "Version": "4.0.3",
       "Source": "Repository",
       "Title": "Create Elegant Data Visualisations Using the Grammar of Graphics",
       "Authors@R": "c( person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = \"aut\", comment = c(ORCID = \"0000-0003-4757-117X\")), person(\"Winston\", \"Chang\", role = \"aut\", comment = c(ORCID = \"0000-0002-1576-2126\")), person(\"Lionel\", \"Henry\", role = \"aut\"), person(\"Thomas Lin\", \"Pedersen\", , \"thomas.pedersen@posit.co\", role = c(\"aut\", \"cre\"), comment = c(ORCID = \"0000-0002-5147-4711\")), person(\"Kohske\", \"Takahashi\", role = \"aut\"), person(\"Claus\", \"Wilke\", role = \"aut\", comment = c(ORCID = \"0000-0002-7470-9261\")), person(\"Kara\", \"Woo\", role = \"aut\", comment = c(ORCID = \"0000-0002-5125-4188\")), person(\"Hiroaki\", \"Yutani\", role = \"aut\", comment = c(ORCID = \"0000-0002-3385-7233\")), person(\"Dewey\", \"Dunnington\", role = \"aut\", comment = c(ORCID = \"0000-0002-9415-4582\")), person(\"Teun\", \"van den Brand\", role = \"aut\", comment = c(ORCID = \"0000-0002-9335-7468\")), person(\"Posit, PBC\", role = c(\"cph\", \"fnd\"), comment = c(ROR = \"03wc8by49\")) )",
@@ -3948,7 +3954,7 @@
     },
     "ggsci": {
       "Package": "ggsci",
-      "Version": "4.3.0",
+      "Version": "5.0.0",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Scientific Journal and Sci-Fi Themed Color Palettes for 'ggplot2'",
@@ -4129,12 +4135,12 @@
     },
     "glmnet": {
       "Package": "glmnet",
-      "Version": "4.1-10",
+      "Version": "5.0",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Lasso and Elastic-Net Regularized Generalized Linear Models",
-      "Date": "2025-07-15",
-      "Authors@R": "c(person(\"Jerome\", \"Friedman\", role=c(\"aut\")), person(\"Trevor\", \"Hastie\", role=c(\"aut\", \"cre\"), email = \"hastie@stanford.edu\"), person(\"Rob\", \"Tibshirani\", role=c(\"aut\")), person(\"Balasubramanian\", \"Narasimhan\", role=c(\"aut\")), person(\"Kenneth\",\"Tay\",role=c(\"aut\")), person(\"Noah\", \"Simon\", role=c(\"aut\")), person(\"Junyang\", \"Qian\", role=c(\"ctb\")), person(\"James\", \"Yang\", role=c(\"aut\")))",
+      "Date": "2026-04-27",
+      "Authors@R": "c(person(\"Jerome\", \"Friedman\", role=c(\"aut\")), person(\"Trevor\", \"Hastie\", role=c(\"aut\", \"cre\"), email = \"hastie@stanford.edu\"), person(\"Rob\", \"Tibshirani\", role=c(\"aut\")), person(\"Balasubramanian\", \"Narasimhan\", role=c(\"aut\")), person(\"Kenneth\",\"Tay\",role=c(\"aut\")), person(\"Noah\", \"Simon\", role=c(\"aut\")), person(\"Junyang\", \"Qian\", role=c(\"ctb\")), person(\"James\", \"Yang\", role=c(\"aut\")), person(\"Jonathan\",\"Taylor\", role=c(\"aut\")))",
       "Depends": [
         "R (>= 3.6.0)",
         "Matrix (>= 1.0-6)"
@@ -4150,6 +4156,7 @@
       "Suggests": [
         "knitr",
         "lars",
+        "nnet",
         "testthat",
         "xfun",
         "rmarkdown"
@@ -4160,13 +4167,13 @@
       "VignetteBuilder": "knitr",
       "Encoding": "UTF-8",
       "URL": "https://glmnet.stanford.edu",
-      "RoxygenNote": "7.3.2",
+      "RoxygenNote": "7.3.3",
       "LinkingTo": [
         "RcppEigen",
         "Rcpp"
       ],
       "NeedsCompilation": "yes",
-      "Author": "Jerome Friedman [aut], Trevor Hastie [aut, cre], Rob Tibshirani [aut], Balasubramanian Narasimhan [aut], Kenneth Tay [aut], Noah Simon [aut], Junyang Qian [ctb], James Yang [aut]",
+      "Author": "Jerome Friedman [aut], Trevor Hastie [aut, cre], Rob Tibshirani [aut], Balasubramanian Narasimhan [aut], Kenneth Tay [aut], Noah Simon [aut], Junyang Qian [ctb], James Yang [aut], Jonathan Taylor [aut]",
       "Maintainer": "Trevor Hastie <hastie@stanford.edu>",
       "Repository": "CRAN"
     },
@@ -4198,16 +4205,16 @@
     },
     "glue": {
       "Package": "glue",
-      "Version": "1.8.0",
+      "Version": "1.8.1",
       "Source": "Repository",
       "Title": "Interpreted String Literals",
-      "Authors@R": "c( person(\"Jim\", \"Hester\", role = \"aut\", comment = c(ORCID = \"0000-0002-2739-7082\")), person(\"Jennifer\", \"Bryan\", , \"jenny@posit.co\", role = c(\"aut\", \"cre\"), comment = c(ORCID = \"0000-0002-6983-2759\")), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")) )",
+      "Authors@R": "c( person(\"Jim\", \"Hester\", role = \"aut\", comment = c(ORCID = \"0000-0002-2739-7082\")), person(\"Jennifer\", \"Bryan\", , \"jenny@posit.co\", role = c(\"aut\", \"cre\"), comment = c(ORCID = \"0000-0002-6983-2759\")), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"), comment = c(ROR = \"03wc8by49\")) )",
       "Description": "An implementation of interpreted string literals, inspired by Python's Literal String Interpolation <https://www.python.org/dev/peps/pep-0498/> and Docstrings <https://www.python.org/dev/peps/pep-0257/> and Julia's Triple-Quoted String Literals <https://docs.julialang.org/en/v1.3/manual/strings/#Triple-Quoted-String-Literals-1>.",
       "License": "MIT + file LICENSE",
       "URL": "https://glue.tidyverse.org/, https://github.com/tidyverse/glue",
       "BugReports": "https://github.com/tidyverse/glue/issues",
       "Depends": [
-        "R (>= 3.6)"
+        "R (>= 4.1)"
       ],
       "Imports": [
         "methods"
@@ -4217,7 +4224,6 @@
         "DBI (>= 1.2.0)",
         "dplyr",
         "knitr",
-        "magrittr",
         "rlang",
         "rmarkdown",
         "RSQLite",
@@ -4230,10 +4236,11 @@
       "ByteCompile": "true",
       "Config/Needs/website": "bench, forcats, ggbeeswarm, ggplot2, R.utils, rprintf, tidyr, tidyverse/tidytemplate",
       "Config/testthat/edition": "3",
+      "Config/usethis/last-upkeep": "2026-04-16",
       "Encoding": "UTF-8",
-      "RoxygenNote": "7.3.2",
+      "RoxygenNote": "7.3.3",
       "NeedsCompilation": "yes",
-      "Author": "Jim Hester [aut] (<https://orcid.org/0000-0002-2739-7082>), Jennifer Bryan [aut, cre] (<https://orcid.org/0000-0002-6983-2759>), Posit Software, PBC [cph, fnd]",
+      "Author": "Jim Hester [aut] (ORCID: <https://orcid.org/0000-0002-2739-7082>), Jennifer Bryan [aut, cre] (ORCID: <https://orcid.org/0000-0002-6983-2759>), Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
       "Maintainer": "Jennifer Bryan <jenny@posit.co>",
       "Repository": "CRAN"
     },
@@ -4524,7 +4531,7 @@
     },
     "htmlTable": {
       "Package": "htmlTable",
-      "Version": "2.4.3",
+      "Version": "2.5.0",
       "Source": "Repository",
       "Title": "Advanced Tables for Markdown/HTML",
       "Authors@R": "c( person(\"Max\", \"Gordon\", email = \"max@gforge.se\", role = c(\"aut\", \"cre\")), person(\"Stephen\", \"Gragg\", role=c(\"aut\")), person(\"Peter\", \"Konings\", role=c(\"aut\")))",
@@ -4566,7 +4573,7 @@
       "Encoding": "UTF-8",
       "NeedsCompilation": "no",
       "VignetteBuilder": "knitr",
-      "RoxygenNote": "7.2.2",
+      "RoxygenNote": "7.3.3",
       "Author": "Max Gordon [aut, cre], Stephen Gragg [aut], Peter Konings [aut]",
       "Repository": "CRAN"
     },
@@ -5069,7 +5076,7 @@
     },
     "jaspAnova": {
       "Package": "jaspAnova",
-      "Version": "0.96.3",
+      "Version": "0.96.6",
       "Source": "GitHub",
       "Type": "Package",
       "Title": "ANOVA Module for JASP",
@@ -5110,7 +5117,7 @@
       "RemoteUsername": "jasp-stats",
       "RemoteRepo": "jaspAnova",
       "RemoteRef": "master",
-      "RemoteSha": "707969a32186f629d2534a2565070fbfd825aac6",
+      "RemoteSha": "a0d8fdb74ecc5e760d16e5ff04f8be9d8c0a3a85",
       "RemoteHost": "api.github.com"
     },
     "jaspBase": {
@@ -5165,11 +5172,11 @@
       "RemoteUsername": "jasp-stats",
       "RemoteRepo": "jaspBase",
       "RemoteRef": "master",
-      "RemoteSha": "951dc3b69177f9498f617c6661f75f72e3082d3e"
+      "RemoteSha": "0f9bd7d846d8432301ccf7bbdcdadcb350df0704"
     },
     "jaspDescriptives": {
       "Package": "jaspDescriptives",
-      "Version": "0.96.2",
+      "Version": "0.96.5",
       "Source": "GitHub",
       "Type": "Package",
       "Title": "Descriptives Module for JASP",
@@ -5201,11 +5208,11 @@
       "RoxygenNote": "7.3.3",
       "RemoteType": "github",
       "Remotes": "jasp-stats/jaspBase, jasp-stats/jaspGraphs, jasp-stats/jaspTTests, dustinfife/flexplot",
+      "RemoteHost": "api.github.com",
       "RemoteUsername": "jasp-stats",
       "RemoteRepo": "jaspDescriptives",
       "RemoteRef": "master",
-      "RemoteSha": "f7795679d7495b4caf9230922b42046197c40d93",
-      "RemoteHost": "api.github.com"
+      "RemoteSha": "fd5479ee5ec7567f7a7c86c40791f54b3370f8af"
     },
     "jaspGraphs": {
       "Package": "jaspGraphs",
@@ -5243,7 +5250,7 @@
       "RemoteUsername": "jasp-stats",
       "RemoteRepo": "jaspGraphs",
       "RemoteRef": "master",
-      "RemoteSha": "db3c899263a1d8d236ed0e7e3a7b6814b48c14ae"
+      "RemoteSha": "1eb48e7e0fe9559bbd15da25f30703c7cca246bb"
     },
     "jaspRegression": {
       "Package": "jaspRegression",
@@ -5299,7 +5306,7 @@
     },
     "jaspTTests": {
       "Package": "jaspTTests",
-      "Version": "0.96.2",
+      "Version": "0.96.5",
       "Source": "GitHub",
       "Type": "Package",
       "Title": "T-Tests Module for JASP",
@@ -5327,7 +5334,7 @@
       "RemoteUsername": "jasp-stats",
       "RemoteRepo": "jaspTTests",
       "RemoteRef": "master",
-      "RemoteSha": "c109eeb10d90842a77c6b8f49b8b813be61d909b"
+      "RemoteSha": "e7e4ecba502b472d9a9564e4ee67f301143b99ac"
     },
     "jaspTools": {
       "Package": "jaspTools",
@@ -6147,11 +6154,10 @@
     },
     "mdscore": {
       "Package": "mdscore",
-      "Version": "0.1-3",
+      "Version": "0.1-4",
       "Source": "Repository",
-      "Type": "Package",
       "Title": "Improved Score Tests for Generalized Linear Models",
-      "Date": "2017-02-16",
+      "Date": "2026-05-05",
       "Depends": [
         "R (>= 3.3.2)",
         "MASS",
@@ -6160,14 +6166,17 @@
       "Suggests": [
         "Sleuth3"
       ],
-      "Authors@R": "c(person(\"Antonio Hermes M.\",\"da Silva-Junior\",  email = \"hermes@ccet.ufrn.br\", role = c(\"aut\", \"cre\")), person(\"Damiao N.\",\"da Silva\",  email = \"damiao@ccet.ufrn.br\", role = \"aut\"), person(\"Silvia L. P.\", \"Ferrari\", email = \"silviaferrari.usp@gmail.com\", role = \"ctb\"))",
-      "Author": "Antonio Hermes M. da Silva-Junior [aut, cre], Damiao N. da Silva [aut], Silvia L. P. Ferrari [ctb]",
-      "Maintainer": "Antonio Hermes M. da Silva-Junior <hermes@ccet.ufrn.br>",
+      "Authors@R": "c(person(\"Iago\", \"Giné-Vázquez\", email = \"iago.gin-vaz@protonmail.com\", comment = c(ORCID = \"0000-0002-3205-0921\"), role = \"cre\"), person(\"Antonio Hermes M.\",\"da Silva-Junior\",  email = \"hermes@ccet.ufrn.br\", role = c(\"aut\")), person(\"Damiao N.\",\"da Silva\",  email = \"damiao@ccet.ufrn.br\", role = \"aut\"), person(\"Silvia L. P.\", \"Ferrari\", email = \"silviaferrari.usp@gmail.com\", role = \"ctb\"))",
       "Description": "A set of functions to obtain modified score test for generalized linear models.",
+      "URL": "https://codeberg.org/iagogv/mdscore",
+      "BugReports": "https://codeberg.org/iagogv/mdscore/issues",
       "License": "GPL (>= 2)",
       "LazyLoad": "yes",
       "LazyData": "yes",
       "NeedsCompilation": "no",
+      "Encoding": "UTF-8",
+      "Author": "Iago Giné-Vázquez [cre] (ORCID: <https://orcid.org/0000-0002-3205-0921>), Antonio Hermes M. da Silva-Junior [aut], Damiao N. da Silva [aut], Silvia L. P. Ferrari [ctb]",
+      "Maintainer": "Iago Giné-Vázquez <iago.gin-vaz@protonmail.com>",
       "Repository": "CRAN"
     },
     "memoise": {
@@ -6620,10 +6629,10 @@
     },
     "mvtnorm": {
       "Package": "mvtnorm",
-      "Version": "1.3-6",
+      "Version": "1.3-7",
       "Source": "Repository",
       "Title": "Multivariate Normal and t Distributions",
-      "Date": "2026-03-13",
+      "Date": "2026-04-14",
       "Authors@R": "c(person(\"Alan\", \"Genz\", role = \"aut\"), person(\"Frank\", \"Bretz\", role = \"aut\"), person(\"Tetsuhisa\", \"Miwa\", role = \"aut\"), person(\"Xuefei\", \"Mi\", role = \"aut\"), person(\"Friedrich\", \"Leisch\", role = \"ctb\"), person(\"Fabian\", \"Scheipl\", role = \"ctb\"), person(\"Bjoern\", \"Bornkamp\", role = \"ctb\", comment = c(ORCID = \"0000-0002-6294-8185\")), person(\"Martin\", \"Maechler\", role = \"ctb\", comment = c(ORCID = \"0000-0002-8685-9910\")), person(\"Torsten\", \"Hothorn\", role = c(\"aut\", \"cre\"), email = \"Torsten.Hothorn@R-project.org\", comment = c(ORCID = \"0000-0001-8301-0471\")))",
       "Description": "Computes multivariate normal and t probabilities, quantiles, random deviates,  and densities. Log-likelihoods for multivariate Gaussian models and Gaussian copulae  parameterised by Cholesky factors of covariance or precision matrices are implemented  for interval-censored and exact data, or a mix thereof. Score functions for these  log-likelihoods are available. A class representing multiple lower triangular matrices  and corresponding methods are part of this package.",
       "Imports": [
@@ -6787,7 +6796,7 @@
     },
     "officer": {
       "Package": "officer",
-      "Version": "0.7.3",
+      "Version": "0.7.4",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Manipulation of Microsoft Word and PowerPoint Documents",
@@ -6820,12 +6829,13 @@
         "magick",
         "rmarkdown",
         "rsvg",
+        "mschart",
         "testthat",
         "withr"
       ],
       "Encoding": "UTF-8",
       "RoxygenNote": "7.3.3",
-      "Collate": "'core_properties.R' 'custom_properties.R' 'defunct.R' 'dev-utils.R' 'docx_add.R' 'docx_comments.R' 'docx_cursor.R' 'docx_part.R' 'docx_replace.R' 'docx_section.R' 'docx_settings.R' 'docx_styles.R' 'docx_utils_funs.R' 'empty_content.R' 'formatting_properties.R' 'fortify_docx.R' 'fortify_pptx.R' 'knitr_utils.R' 'officer.R' 'ooxml.R' 'ooxml_block_objects.R' 'ooxml_run_objects.R' 'openxml_content_type.R' 'openxml_document.R' 'pack_folder.R' 'ph_location.R' 'post-proc.R' 'ppt_class_dir_collection.R' 'ppt_classes.R' 'ppt_notes.R' 'ppt_ph_dedupe_layout.R' 'ppt_ph_manipulate.R' 'ppt_ph_rename_layout.R' 'ppt_ph_with_methods.R' 'pptx_informations.R' 'pptx_layout_helper.R' 'pptx_matrix.R' 'utils.R' 'pptx_slide_manip.R' 'read_docx.R' 'docx_write.R' 'read_docx_styles.R' 'read_pptx.R' 'read_xlsx.R' 'relationship.R' 'rtf.R' 'shape_properties.R' 'shorcuts.R' 'docx_append_context.R' 'utils-xml.R' 'deprecated.R' 'zzz.R'",
+      "Collate": "'core_properties.R' 'custom_properties.R' 'defunct.R' 'dev-utils.R' 'docx_add.R' 'docx_comments.R' 'docx_cursor.R' 'docx_embed_font.R' 'docx_part.R' 'docx_replace.R' 'docx_section.R' 'docx_settings.R' 'docx_styles.R' 'docx_utils_funs.R' 'empty_content.R' 'formatting_properties.R' 'fortify_docx.R' 'fortify_pptx.R' 'knitr_utils.R' 'officer.R' 'ooxml.R' 'ooxml_block_objects.R' 'ooxml_run_objects.R' 'openxml_content_type.R' 'openxml_document.R' 'pack_folder.R' 'ph_location.R' 'post-proc.R' 'ppt_class_dir_collection.R' 'ppt_classes.R' 'ppt_notes.R' 'ppt_ph_dedupe_layout.R' 'ppt_ph_manipulate.R' 'ppt_ph_rename_layout.R' 'ppt_ph_with_methods.R' 'pptx_informations.R' 'pptx_layout_helper.R' 'pptx_matrix.R' 'utils.R' 'pptx_slide_manip.R' 'read_docx.R' 'docx_write.R' 'read_docx_styles.R' 'read_pptx.R' 'read_xlsx.R' 'relationship.R' 'rtf.R' 'shape_properties.R' 'shorcuts.R' 'docx_append_context.R' 'utils-xml.R' 'deprecated.R' 'zzz.R'",
       "NeedsCompilation": "no",
       "Author": "David Gohel [aut, cre], Stefan Moog [aut], Mark Heckmann [aut] (ORCID: <https://orcid.org/0000-0002-0736-7417>), ArData [cph], Frank Hangler [ctb] (function body_replace_all_text), Liz Sander [ctb] (several documentation fixes), Anton Victorson [ctb] (fixes xml structures), Jon Calder [ctb] (update vignettes), John Harrold [ctb] (function annotate_base), John Muschelli [ctb] (google doc compatibility), Bill Denney [ctb] (ORCID: <https://orcid.org/0000-0002-5759-428X>, function as.matrix.rpptx), Nikolai Beck [ctb] (set speaker notes for .pptx documents), Greg Leleu [ctb] (fields functionality in ppt), Majid Eismann [ctb], Wahiduzzaman Khan [ctb] (vectorization of remove_slide), Hongyuan Jia [ctb] (ORCID: <https://orcid.org/0000-0002-0075-8183>), Michael Stackhouse [ctb]",
       "Maintainer": "David Gohel <david.gohel@ardata.fr>",
@@ -6866,7 +6876,7 @@
     },
     "openssl": {
       "Package": "openssl",
-      "Version": "2.3.5",
+      "Version": "2.4.0",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Toolkit for Encryption, Signatures and Certificates Based on OpenSSL",
@@ -6999,7 +7009,7 @@
     },
     "pak": {
       "Package": "pak",
-      "Version": "0.9.3",
+      "Version": "0.9.5",
       "Source": "Repository",
       "Title": "Another Approach to Package Installation",
       "Authors@R": "c( person(\"Gábor\", \"Csárdi\", , \"csardi.gabor@gmail.com\", role = c(\"aut\", \"cre\")), person(\"Jim\", \"Hester\", role = \"aut\"), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"), comment = c(ROR = \"03wc8by49\")), person(\"Winston\", \"Chang\", role = \"ctb\", comment = \"R6, callr, processx\"), person(\"Ascent Digital Services\", role = c(\"cph\", \"fnd\"), comment = \"callr, processx\"), person(\"Hadley\", \"Wickham\", role = c(\"ctb\", \"cph\"), comment = \"cli, curl, pkgbuild, yaml\"), person(\"Jeroen\", \"Ooms\", role = \"ctb\", comment = \"curl, jsonlite\"), person(\"Maëlle\", \"Salmon\", role = \"ctb\", comment = \"desc, pkgsearch\"), person(\"Duncan\", \"Temple Lang\", role = \"ctb\", comment = \"jsonlite\"), person(\"Lloyd\", \"Hilaiel\", role = \"cph\", comment = \"jsonlite\"), person(\"Alec\", \"Wong\", role = \"ctb\", comment = \"keyring\"), person(\"Michel Berkelaar and lpSolve authors\", role = \"ctb\", comment = \"lpSolve\"), person(\"R Consortium\", role = \"fnd\", comment = \"pkgsearch\"), person(\"Jay\", \"Loden\", role = \"ctb\", comment = \"ps\"), person(\"Dave\", \"Daeschler\", role = \"ctb\", comment = \"ps\"), person(\"Giampaolo\", \"Rodola\", role = \"ctb\", comment = \"ps\"), person(\"Shawn\", \"Garbett\", role = \"ctb\", comment = \"yaml\"), person(\"Jeremy\", \"Stephens\", role = \"ctb\", comment = \"yaml\"), person(\"Kirill\", \"Simonov\", role = \"ctb\", comment = \"yaml\"), person(\"Yihui\", \"Xie\", role = \"ctb\", comment = \"yaml\"), person(\"Zhuoer\", \"Dong\", role = \"ctb\", comment = \"yaml\"), person(\"Jeffrey\", \"Horner\", role = \"ctb\", comment = \"yaml\"), person(\"Will\", \"Beasley\", role = \"ctb\", comment = \"yaml\"), person(\"Brendan\", \"O'Connor\", role = \"ctb\", comment = \"yaml\"), person(\"Gregory\", \"Warnes\", role = \"ctb\", comment = \"yaml\"), person(\"Michael\", \"Quinn\", role = \"ctb\", comment = \"yaml\"), person(\"Zhian\", \"Kamvar\", role = \"ctb\", comment = \"yaml\"), person(\"Charlie\", \"Gao\", role = \"ctb\", comment = \"yaml\"), person(\"Kuba\", \"Podgórski\", role = \"ctb\", comment = \"zip\"), person(\"Rich\", \"Geldreich\", role = \"ctb\", comment = \"zip\") )",
@@ -7048,7 +7058,7 @@
       "Config/testthat/edition": "3",
       "Config/usethis/last-upkeep": "2025-05-13",
       "Encoding": "UTF-8",
-      "RoxygenNote": "7.3.2.9000",
+      "RoxygenNote": "7.3.3",
       "NeedsCompilation": "yes",
       "Author": "Gábor Csárdi [aut, cre], Jim Hester [aut], Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>), Winston Chang [ctb] (R6, callr, processx), Ascent Digital Services [cph, fnd] (callr, processx), Hadley Wickham [ctb, cph] (cli, curl, pkgbuild, yaml), Jeroen Ooms [ctb] (curl, jsonlite), Maëlle Salmon [ctb] (desc, pkgsearch), Duncan Temple Lang [ctb] (jsonlite), Lloyd Hilaiel [cph] (jsonlite), Alec Wong [ctb] (keyring), Michel Berkelaar and lpSolve authors [ctb] (lpSolve), R Consortium [fnd] (pkgsearch), Jay Loden [ctb] (ps), Dave Daeschler [ctb] (ps), Giampaolo Rodola [ctb] (ps), Shawn Garbett [ctb] (yaml), Jeremy Stephens [ctb] (yaml), Kirill Simonov [ctb] (yaml), Yihui Xie [ctb] (yaml), Zhuoer Dong [ctb] (yaml), Jeffrey Horner [ctb] (yaml), Will Beasley [ctb] (yaml), Brendan O'Connor [ctb] (yaml), Gregory Warnes [ctb] (yaml), Michael Quinn [ctb] (yaml), Zhian Kamvar [ctb] (yaml), Charlie Gao [ctb] (yaml), Kuba Podgórski [ctb] (zip), Rich Geldreich [ctb] (zip)",
       "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
@@ -7078,7 +7088,7 @@
     },
     "parallelly": {
       "Package": "parallelly",
-      "Version": "1.46.1",
+      "Version": "1.47.0",
       "Source": "Repository",
       "Title": "Enhancing the 'parallel' Package",
       "Imports": [
@@ -7755,7 +7765,7 @@
     },
     "pkgload": {
       "Package": "pkgload",
-      "Version": "1.5.1",
+      "Version": "1.5.2",
       "Source": "Repository",
       "Title": "Simulate Package Installation and Attach",
       "Authors@R": "c( person(\"Hadley\", \"Wickham\", role = \"aut\"), person(\"Winston\", \"Chang\", role = \"aut\"), person(\"Jim\", \"Hester\", role = \"aut\"), person(\"Lionel\", \"Henry\", , \"lionel@posit.co\", role = c(\"aut\", \"cre\")), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")), person(\"R Core team\", role = \"ctb\", comment = \"Some namespace and vignette code extracted from base R\") )",
@@ -8045,7 +8055,7 @@
     },
     "processx": {
       "Package": "processx",
-      "Version": "3.8.7",
+      "Version": "3.9.0",
       "Source": "Repository",
       "Title": "Execute and Control System Processes",
       "Authors@R": "c( person(\"Gábor\", \"Csárdi\", , \"csardi.gabor@gmail.com\", role = c(\"aut\", \"cre\", \"cph\"), comment = c(ORCID = \"0000-0001-7098-9676\")), person(\"Winston\", \"Chang\", role = \"aut\"), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"), comment = c(ROR = \"03wc8by49\")), person(\"Ascent Digital Services\", role = c(\"cph\", \"fnd\")) )",
@@ -8057,7 +8067,7 @@
         "R (>= 3.4.0)"
       ],
       "Imports": [
-        "ps (>= 1.2.0)",
+        "ps (>= 1.9.3)",
         "R6",
         "utils"
       ],
@@ -8078,7 +8088,7 @@
       "Config/testthat/edition": "3",
       "Config/usethis/last-upkeep": "2025-04-25",
       "Encoding": "UTF-8",
-      "RoxygenNote": "7.3.2",
+      "RoxygenNote": "7.3.3",
       "NeedsCompilation": "yes",
       "Author": "Gábor Csárdi [aut, cre, cph] (ORCID: <https://orcid.org/0000-0001-7098-9676>), Winston Chang [aut], Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>), Ascent Digital Services [cph, fnd]",
       "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
@@ -8250,7 +8260,7 @@
     },
     "ps": {
       "Package": "ps",
-      "Version": "1.9.2",
+      "Version": "1.9.3",
       "Source": "Repository",
       "Title": "List, Query, Manipulate System Processes",
       "Authors@R": "c( person(\"Jay\", \"Loden\", role = \"aut\"), person(\"Dave\", \"Daeschler\", role = \"aut\"), person(\"Giampaolo\", \"Rodola'\", role = \"aut\"), person(\"Gábor\", \"Csárdi\", , \"csardi.gabor@gmail.com\", role = c(\"aut\", \"cre\")), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"), comment = c(ROR = \"03wc8by49\")) )",
@@ -8282,7 +8292,7 @@
       "Config/testthat/edition": "3",
       "Config/usethis/last-upkeep": "2025-04-28",
       "Encoding": "UTF-8",
-      "RoxygenNote": "7.3.2",
+      "RoxygenNote": "7.3.3",
       "NeedsCompilation": "yes",
       "Author": "Jay Loden [aut], Dave Daeschler [aut], Giampaolo Rodola' [aut], Gábor Csárdi [aut, cre], Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
       "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
@@ -8669,7 +8679,7 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "1.2.1",
+      "Version": "1.2.2",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Project Environments",
@@ -8924,7 +8934,7 @@
     },
     "roxygen2": {
       "Package": "roxygen2",
-      "Version": "7.3.3",
+      "Version": "8.0.0",
       "Source": "Repository",
       "Title": "In-Line Documentation for R",
       "Authors@R": "c( person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = c(\"aut\", \"cre\", \"cph\"), comment = c(ORCID = \"0000-0003-4757-117X\")), person(\"Peter\", \"Danenberg\", , \"pcd@roxygen.org\", role = c(\"aut\", \"cph\")), person(\"Gábor\", \"Csárdi\", , \"csardi.gabor@gmail.com\", role = \"aut\"), person(\"Manuel\", \"Eugster\", role = c(\"aut\", \"cph\")), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"), comment = c(ROR = \"03wc8by49\")) )",
@@ -8933,7 +8943,7 @@
       "URL": "https://roxygen2.r-lib.org/, https://github.com/r-lib/roxygen2",
       "BugReports": "https://github.com/r-lib/roxygen2/issues",
       "Depends": [
-        "R (>= 3.6)"
+        "R (>= 4.1)"
       ],
       "Imports": [
         "brew",
@@ -8941,13 +8951,11 @@
         "commonmark",
         "desc (>= 1.2.0)",
         "knitr",
+        "lifecycle",
         "methods",
-        "pkgload (>= 1.0.2)",
-        "purrr (>= 1.0.0)",
+        "pkgload (>= 1.5.2)",
         "R6 (>= 2.1.2)",
-        "rlang (>= 1.0.6)",
-        "stringi",
-        "stringr (>= 1.0.0)",
+        "rlang (>= 1.1.0)",
         "utils",
         "withr",
         "xml2"
@@ -8955,6 +8963,7 @@
       "Suggests": [
         "covr",
         "R.methodsS3",
+        "S7",
         "R.oo",
         "rmarkdown (>= 2.16)",
         "testthat (>= 3.1.2)",
@@ -8966,11 +8975,13 @@
       "VignetteBuilder": "knitr",
       "Config/Needs/development": "testthat",
       "Config/Needs/website": "tidyverse/tidytemplate",
+      "Config/roxygen2/load": "installed",
+      "Config/roxygen2/markdown": "TRUE",
+      "Config/roxygen2/version": "7.3.3.9000",
       "Config/testthat/edition": "3",
       "Config/testthat/parallel": "TRUE",
       "Encoding": "UTF-8",
       "Language": "en-GB",
-      "RoxygenNote": "7.3.2.9000",
       "NeedsCompilation": "yes",
       "Author": "Hadley Wickham [aut, cre, cph] (ORCID: <https://orcid.org/0000-0003-4757-117X>), Peter Danenberg [aut, cph], Gábor Csárdi [aut], Manuel Eugster [aut, cph], Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
       "Maintainer": "Hadley Wickham <hadley@posit.co>",
@@ -9144,7 +9155,7 @@
     },
     "rvg": {
       "Package": "rvg",
-      "Version": "0.4.1",
+      "Version": "0.4.2",
       "Source": "Repository",
       "Type": "Package",
       "Title": "R Graphics Devices for 'Office' Vector Graphics Output",
@@ -9159,7 +9170,7 @@
       "Imports": [
         "gdtools (>= 0.5.0)",
         "grDevices",
-        "officer (>= 0.6.2)",
+        "officer (>= 0.7.4)",
         "Rcpp (>= 0.12.12)",
         "rlang",
         "systemfonts",

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,8 +2,8 @@
 local({
 
   # the requested version of renv
-  version <- "1.2.1"
-  attr(version, "md5") <- "51fff37c14949274ac148a9a087ab6bd"
+  version <- "1.2.2"
+  attr(version, "md5") <- "bb69b6403b1bad0442657e9e8e57cc83"
   attr(version, "sha") <- NULL
 
   # the project directory

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,8 +2,8 @@
 local({
 
   # the requested version of renv
-  version <- "1.2.2"
-  attr(version, "md5") <- "bb69b6403b1bad0442657e9e8e57cc83"
+  version <- "1.2.3"
+  attr(version, "md5") <- "1bd9f58e1cfe27ce035933937c6f03de"
   attr(version, "sha") <- NULL
 
   # the project directory


### PR DESCRIPTION
This PR adds two primary things:

1. Correct (I think, no unit tests yet) pooling for the fit difference stats and information criteria.
   - I'm currently working on unit tests for all the added regression stuff. Those tests are coming in a future PR.
1. Links between various QML files to make the variables form in the regression analysis use the variables selected in the MI section as its source.
   - Fixes #49
 
*NOTE:* Many of the apparent changes are only trivial formatting tweaks since I recently started using [Air](https://posit-dev.github.io/air/) to auto-format my source code.