### PR TITLE
small patch to make mi regression not break with only dv

### DIFF
--- a/R/miLinearRegression.R
+++ b/R/miLinearRegression.R
@@ -27,9 +27,11 @@
   ## We need to recompute the F-tests for the R2 changes since they're not pooled correctly in .linregCalcModel()
   model[[1]][["rSquareChange"]] <- .pooledRSquaredChange(fit1 = model[[1]]$fit)
 
-  for (i in seq_along(model)[-1]) {
-    model[[i]][["rSquareChange"]] <- .pooledRSquaredChange(fit1 = model[[i]]$fit, fit0 = model[[i - 1]]$fit)
-    # durbinWatson  <- model[[i]][["durbinWatson"]]
+  if (length(options$covariates) + length(options$factors) > 0) {
+    for (i in seq_along(model)[-1]) {
+      model[[i]][["rSquareChange"]] <- .pooledRSquaredChange(fit1 = model[[i]]$fit, fit0 = model[[i - 1]]$fit)
+      # durbinWatson  <- model[[i]][["durbinWatson"]]
+    }
   }
 
   if (is.null(modelContainer[["summaryTable"]])) {


### PR DESCRIPTION
Currently, mice regression breaks when only the dependent variable is included. This small patch makes its behavior compatible with the normal regression module in JASP.

I think @kylelang won't respond because he's going on holiday, and the patch is really small, so you can also review it if you feel qualified, @DSWestbeek. 